### PR TITLE
Fixed boundary calculation bug in the fold method

### DIFF
--- a/bqskit/ir/circuit.py
+++ b/bqskit/ir/circuit.py
@@ -1130,6 +1130,7 @@ class Circuit(DifferentiableUnitary, StateVectorMap, Collection[Operation]):
                         bounds[0] - 1 - i,
                         boundary[qudit_index][1],
                     )
+                    break
 
             for i, cycle in enumerate(self._circuit[bounds[1] + 1:]):
                 if cycle[qudit_index] is not None:
@@ -1137,6 +1138,7 @@ class Circuit(DifferentiableUnitary, StateVectorMap, Collection[Operation]):
                         boundary[qudit_index][0],
                         bounds[1] + 1 + i,
                     )
+                    break
 
         # Push outside gates to side if necessary
         region_back_min = min(bound[0] for bound in region.values())


### PR DESCRIPTION
The following example shows the boundary values before and after the bug fix.

```
from bqskit import Circuit
from bqskit.ir.gates.constant.h import HGate

# Prepare circuit
circ = Circuit(3)
circ.append_gate(HGate(), [0])
circ.append_gate(HGate(), [1])
circ.append_gate(HGate(), [0])
circ.append_gate(HGate(), [2])
circ.append_gate(HGate(), [0])
circ.append_gate(HGate(), [1])
circ.append_gate(HGate(), [2])
fold_1 = [(0,0), (0,1)]
fold_2 = [(1,0), (1,2)]
fold_3 = [(2,0), (1,1), (1,2)]

# Expected boundaries:
# 0 : (-1,1)
# 1 : (-1,1)
# Observed boundaries:
# 0 : (-1,1)
# 1 : (-1,1)
circ.fold(fold_1)

# Expected boundaries:
# 0 : (0,2)
# 2 : (-1,1)
# Observed boundaries:
# 0 : (0,2)
# 2 : (0,3)
circ.fold(fold_2)

# Expected boundaries:
# 0 : (1,3)
# 1 : (0,2)
# 2 : (0,2)
# Observed boundaries:
# 0 : (0,3)
# 1 : (0,3)
# 2 : (0,3)
circ.fold(fold_3)
```
KEYWORD BQSKit/bqskit#24