### PR TITLE
Fixed batch_pop bug

### DIFF
--- a/bqskit/ir/circuit.py
+++ b/bqskit/ir/circuit.py
@@ -1001,7 +1001,7 @@ class Circuit(DifferentiableUnitary, StateVectorMap, Collection[Operation]):
                                   for point in points[i + 1:]]
 
         # Form new circuit and return
-        qudits = list(set(sum([op.location for op in ops], ())))
+        qudits = sorted(list(set(sum([op.location for op in ops], ()))))
         radixes = [self.get_radixes()[q] for q in qudits]
         circuit = Circuit(len(radixes), radixes)
         for op in ops:


### PR DESCRIPTION
The `qudits` list in the `batch_pop` method was unsorted, so occasionally when inserting a CircuitGate, the wrong qudits were mapped to. Solves the issue found in KEYWORD #26