### PR TITLE
Fixed bug that selected small regions first

### DIFF
--- a/bqskit/compiler/passes/partitioning/greedy.py
+++ b/bqskit/compiler/passes/partitioning/greedy.py
@@ -96,7 +96,7 @@ class GreedyPartitioner(BasePass):  # TODO: Change
 
             # Pick largest region
             s = sorted(potential_regions.values(), key=lambda x: x[0])
-            num_gates, best_region = s[0]
+            num_gates, best_region = s[-1]
             num_partitioned_gates += num_gates
             regions.append(best_region)
 


### PR DESCRIPTION
There's no need to figure out the merge stuff, the only thing wrong was that the list of `potential_regions` was sorted least to greatest, and we were picking the smaller regions first instead of the larger ones.