### PR TITLE
Fix crash in Compiler due to double close

### DIFF
--- a/bqskit/compiler/compiler.py
+++ b/bqskit/compiler/compiler.py
@@ -23,11 +23,16 @@ class Compiler:
     The compiler class spins up a Dask execution environment, which
     compilation tasks can then access to parallelize their operations.
     The compiler is implemented as a context manager and it is recommended
-    to use it as one.
+    to use it as one. If the compiler is not used in a context manager, it
+    is the responsibility of the user to call `close()`.
 
     Examples:
         >>> with Compiler() as compiler:
         ...     circuit = compiler.compile(task)
+
+        >>> compiler = Compiler()
+        >>> circuit = compiler.compile(task)
+        >>> compiler.close()
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -50,10 +55,6 @@ class Compiler:
         return self
 
     def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
-        """Shutdown compiler."""
-        self.close()
-
-    def __del__(self) -> None:
         """Shutdown compiler."""
         self.close()
 


### PR DESCRIPTION
This fixes a crash that occurred due to the client already being closed in `__exit__` when `Compiler` is used as a context manager, but `close()` is called again in `__del__`. In general `__del__` should not be relied on for resource cleanup, as it may be called at any point after the reference count of an object reaches zero.

We now indicate that users should call `close()` if they do not use the Compiler as a context manager.