### PR TITLE
Fix issue with mypy taking too long to run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,7 @@ repos:
     rev: v0.942
     hooks:
     - id: mypy
+      exclude: tests/qis/test_pauli.py
       additional_dependencies: ["numpy>=1.21"]
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2


### PR DESCRIPTION
A clean `pre-commit run mypy --all-files` takes less than 15 seconds!