### PR TITLE
Dask and Logging QOL Improvementes

### DIFF
--- a/bqskit/__init__.py
+++ b/bqskit/__init__.py
@@ -10,12 +10,6 @@ from bqskit.ir.lang import register_language
 from bqskit.ir.lang.qasm2 import OPENQASM2Language
 from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
 
-__all__ = [
-    'CompilationTask',
-    'Compiler',
-    'Circuit',
-    'UnitaryMatrix',
-]
 
 # Initialize Logging
 _logger = logging.getLogger('bqskit')
@@ -27,5 +21,27 @@ _formatter = logging.Formatter(_fmt, '%H:%M:%S')
 _handler.setFormatter(_formatter)
 _logger.addHandler(_handler)
 
+
+def enable_logging(verbose: bool = False) -> None:
+    """
+    Enable logging for BQSKit.
+
+    Args:
+        verbose (bool): If set to True, will print more verbose messages.
+            Defaults to False.
+    """
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.getLogger('bqskit').setLevel(level)
+
+
 # Register supported languages
 register_language('qasm', OPENQASM2Language())
+
+
+__all__ = [
+    'CompilationTask',
+    'Compiler',
+    'Circuit',
+    'UnitaryMatrix',
+    'enable_logging',
+]

--- a/bqskit/compiler/executor.py
+++ b/bqskit/compiler/executor.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from threadpoolctl import threadpool_limits
-
 from bqskit.compiler.task import CompilationTask
 from bqskit.ir.circuit import Circuit
 
@@ -33,8 +31,7 @@ class Executor:
 
     def run(self) -> tuple[Circuit, dict[str, Any]]:
         """Execute the task."""
-        with threadpool_limits(limits=1):
-            for pass_obj in self.passes:
-                pass_obj.run(self.circuit, self.data)
+        for pass_obj in self.passes:
+            pass_obj.run(self.circuit, self.data)
         self.done = True
         return self.circuit, self.data


### PR DESCRIPTION
- Print an error message when a compiler is created outside of a `if __name__ == '__main__'` clause
- Dask logging is now handled separately from BQSKit logging
- BQSKit logging can be enabled by an exported function now: `bqskit.enable_logging`