### PR TITLE
Runtime spawn upgrade

### DIFF
--- a/bqskit/runtime/attached.py
+++ b/bqskit/runtime/attached.py
@@ -60,7 +60,7 @@ class AttachedServer(DetachedServer):
         self.mailbox_counter = 0
 
         # Start workers
-        self.spawn_workers(num_workers)
+        self.spawn_workers(num_workers, worker_port)
 
         # Connect to client
         client_conn = self.listen_once(port)

--- a/bqskit/runtime/base.py
+++ b/bqskit/runtime/base.py
@@ -297,6 +297,8 @@ class ServerBase:
         if num_workers == -1:
             oscount = os.cpu_count()
             num_workers = oscount if oscount else 1
+        
+        self.logger.info(f'Expecting {num_workers} worker connections.')
 
         if self.lower_id_bound + num_workers >= self.upper_id_bound:
             raise RuntimeError('Insufficient id range for workers.')

--- a/bqskit/runtime/base.py
+++ b/bqskit/runtime/base.py
@@ -236,7 +236,7 @@ class ServerBase:
         if self.lower_id_bound + num_workers >= self.upper_id_bound:
             raise RuntimeError('Insufficient id range for workers.')
 
-        # Create and start all worker processed
+        # Create and start all worker processes
         procs = {}
         for i in range(num_workers):
             w_id = self.lower_id_bound + i

--- a/bqskit/runtime/base.py
+++ b/bqskit/runtime/base.py
@@ -297,7 +297,7 @@ class ServerBase:
         if num_workers == -1:
             oscount = os.cpu_count()
             num_workers = oscount if oscount else 1
-        
+
         self.logger.info(f'Expecting {num_workers} worker connections.')
 
         if self.lower_id_bound + num_workers >= self.upper_id_bound:

--- a/bqskit/runtime/detached.py
+++ b/bqskit/runtime/detached.py
@@ -384,7 +384,7 @@ class DetachedServer(ServerBase):
 def start_server() -> None:
     """Entry point for a detached runtime server process."""
     parser = argparse.ArgumentParser(
-        prog='BQSKit Server',
+        prog='bqskit-server',
         description='Launch a BQSKit runtime server process.',
     )
     parser.add_argument(

--- a/bqskit/runtime/manager.py
+++ b/bqskit/runtime/manager.py
@@ -256,7 +256,7 @@ class Manager(ServerBase):
 def start_manager() -> None:
     """Entry point for runtime manager processes."""
     parser = argparse.ArgumentParser(
-        prog='BQSKit Manager',
+        prog='bqskit-manager',
         description='Launch a BQSKit runtime manager process.',
     )
     parser.add_argument(

--- a/bqskit/runtime/manager.py
+++ b/bqskit/runtime/manager.py
@@ -313,10 +313,15 @@ def start_manager() -> None:
     if args.import_tests:
         import_tests_package()
 
+    if args.num_workers < -1:
+        num_workers = -1
+    else:
+        num_workers = args.num_workers
+
     # Create the manager
     manager = Manager(
         args.port,
-        args.num_workers,
+        num_workers,
         ipports,
         args.worker_port,
         args.only_connect,

--- a/bqskit/runtime/manager.py
+++ b/bqskit/runtime/manager.py
@@ -41,6 +41,7 @@ class Manager(ServerBase):
         num_workers: int = -1,
         ipports: list[tuple[str, int]] | None = None,
         worker_port: int = default_worker_port,
+        only_connect: bool = False,
     ) -> None:
         """
         Create a manager instance in one of two ways:
@@ -74,6 +75,9 @@ class Manager(ServerBase):
             worker_port (int): The port this server will listen for workers
                 on. Default can be found in the
                 :obj:`~bqskit.runtime.default_worker_port` global variable.
+
+            only_connect (bool): If true, do not spawn workers, only connect
+                to already spawned workers.
         """
         super().__init__()
 
@@ -93,7 +97,10 @@ class Manager(ServerBase):
 
         # Case 1: spawn and manage workers
         if ipports is None:
-            self.spawn_workers(num_workers, worker_port)
+            if only_connect:
+                self.connect_to_workers(num_workers, worker_port)
+            else:
+                self.spawn_workers(num_workers, worker_port)
 
         # Case 2: Connect to managers at ipports
         else:
@@ -277,13 +284,18 @@ def start_manager() -> None:
         help='The port this manager will listen for workers on.',
     )
     parser.add_argument(
-        '--verbose', '-v',
+        '-x', '--only-connect',
+        action='store_true',
+        help='Do not spawn workers, only connect to them.',
+    )
+    parser.add_argument(
+        '-v', '--verbose',
         action='count',
         default=0,
         help='Enable logging of increasing verbosity, either -v, -vv, or -vvv.',
     )
     parser.add_argument(
-        '--import-tests', '-i',
+        '-i', '--import-tests',
         action='store_true',
         help='Import the bqskit tests package; used during testing.',
     )
@@ -302,7 +314,13 @@ def start_manager() -> None:
         import_tests_package()
 
     # Create the manager
-    manager = Manager(args.port, args.num_workers, ipports, args.worker_port)
+    manager = Manager(
+        args.port,
+        args.num_workers,
+        ipports,
+        args.worker_port,
+        args.only_connect,
+    )
 
     # Start the manager
     manager.run()

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -637,6 +637,11 @@ def get_worker() -> Worker:
         raise RuntimeError('Worker has not been started.')
     return _worker
 
+def _check_positive(value):
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError("%s is an invalid positive int value" % value)
+    return ivalue
 
 def start_worker_rank() -> None:
     """Entry point for spawning a rank of runtime worker processes."""
@@ -646,7 +651,7 @@ def start_worker_rank() -> None:
     )
     parser.add_argument(
         'num_workers',
-        type=int,
+        type=_check_positive,
         help='The number of workers to spawn.',
     )
     parser.add_argument(

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -638,7 +638,7 @@ def get_worker() -> Worker:
     return _worker
 
 
-def _check_positive(value):
+def _check_positive(value: str) -> int:
     ivalue = int(value)
     if ivalue <= 0:
         raise argparse.ArgumentTypeError(

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -637,11 +637,15 @@ def get_worker() -> Worker:
         raise RuntimeError('Worker has not been started.')
     return _worker
 
+
 def _check_positive(value):
     ivalue = int(value)
     if ivalue <= 0:
-        raise argparse.ArgumentTypeError("%s is an invalid positive int value" % value)
+        raise argparse.ArgumentTypeError(
+            '%s is an invalid positive int value' % value,
+        )
     return ivalue
+
 
 def start_worker_rank() -> None:
     """Entry point for spawning a rank of runtime worker processes."""

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -641,7 +641,7 @@ def get_worker() -> Worker:
 def start_worker_rank() -> None:
     """Entry point for spawning a rank of runtime worker processes."""
     parser = argparse.ArgumentParser(
-        prog='BQSKit Worker',
+        prog='bqskit-worker',
         description='Launch a rank of BQSKit runtime worker processes.',
     )
     parser.add_argument(

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ exclude =
 console_scripts =
     bqskit-server = bqskit.runtime.detached:start_server
     bqskit-manager = bqskit.runtime.manager:start_manager
+    bqskit-worker = bqskit.runtime.worker:start_worker_rank
 
 [options.extras_require]
 dev =

--- a/tests/runtime/test_attached.py
+++ b/tests/runtime/test_attached.py
@@ -55,7 +55,8 @@ def test_cleanup_with_clause(num_workers: int) -> None:
 def test_create_workers(num_workers: int) -> None:
     compiler = Compiler(num_workers=num_workers)
     assert compiler.p is not None
-    assert len(psutil.Process(compiler.p.pid).children()) == num_workers
+    expected = [num_workers, num_workers + 1]  # Some OS create a spawn server
+    assert len(psutil.Process(compiler.p.pid).children()) in expected
     compiler.close()
 
 
@@ -66,7 +67,7 @@ def test_one_thread_per_worker() -> None:
 
     compiler = Compiler(num_workers=1)
     assert compiler.p is not None
-    assert len(psutil.Process(compiler.p.pid).children()) == 1
+    assert len(psutil.Process(compiler.p.pid).children()) in [1, 2]
     assert psutil.Process(compiler.p.pid).children()[0].num_threads() == 1
     compiler.close()
 


### PR DESCRIPTION
1. No more `if __name_\_ == ...` errors on Windows and Mac
1. Added the `bqskit-worker` entry point, so you can create and control ranks of workers however you would like
1. If you use `bqskit-worker` you can additionally pin the workers to logical CPU ids