### PR TITLE
adding qudit gates

### DIFF
--- a/bqskit/ir/gates/constant/__init__.py
+++ b/bqskit/ir/gates/constant/__init__.py
@@ -18,6 +18,7 @@ from bqskit.ir.gates.constant.hd import HDGate
 from bqskit.ir.gates.constant.identity import IdentityGate
 from bqskit.ir.gates.constant.iswap import ISwapGate
 from bqskit.ir.gates.constant.itoffoli import IToffoliGate
+from bqskit.ir.gates.constant.pd import PDGate
 from bqskit.ir.gates.constant.permutation import PermutationGate
 from bqskit.ir.gates.constant.s import SGate
 from bqskit.ir.gates.constant.sdg import SdgGate
@@ -56,6 +57,7 @@ __all__ = [
     'IdentityGate',
     'ISwapGate',
     'IToffoliGate',
+    'PDGate',
     'PermutationGate',
     'SGate',
     'SdgGate',

--- a/bqskit/ir/gates/constant/__init__.py
+++ b/bqskit/ir/gates/constant/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from bqskit.ir.gates.constant.ccx import CCXGate
 from bqskit.ir.gates.constant.ccx import ToffoliGate
+from bqskit.ir.gates.constant.clock import ClockGate
 from bqskit.ir.gates.constant.ch import CHGate
 from bqskit.ir.gates.constant.cpi import CPIGate
 from bqskit.ir.gates.constant.cs import CSGate
@@ -13,12 +14,14 @@ from bqskit.ir.gates.constant.cx import CXGate
 from bqskit.ir.gates.constant.cy import CYGate
 from bqskit.ir.gates.constant.cz import CZGate
 from bqskit.ir.gates.constant.h import HGate
+from bqskit.ir.gates.constant.hd import HDGate
 from bqskit.ir.gates.constant.identity import IdentityGate
 from bqskit.ir.gates.constant.iswap import ISwapGate
 from bqskit.ir.gates.constant.itoffoli import IToffoliGate
 from bqskit.ir.gates.constant.permutation import PermutationGate
 from bqskit.ir.gates.constant.s import SGate
 from bqskit.ir.gates.constant.sdg import SdgGate
+from bqskit.ir.gates.constant.shift import ShiftGate
 from bqskit.ir.gates.constant.sqrtcnot import SqrtCNOTGate
 from bqskit.ir.gates.constant.sqrtiswap import SqrtISwapGate
 from bqskit.ir.gates.constant.swap import SwapGate
@@ -39,6 +42,7 @@ __all__ = [
     'CCXGate',
     'ToffoliGate',
     'CHGate',
+    'ClockGate',
     'CPIGate',
     'CSGate',
     'CSUMGate',
@@ -48,12 +52,14 @@ __all__ = [
     'CYGate',
     'CZGate',
     'HGate',
+    'HDGate',
     'IdentityGate',
     'ISwapGate',
     'IToffoliGate',
     'PermutationGate',
     'SGate',
     'SdgGate',
+    'ShiftGate',
     'SqrtCNOTGate',
     'SwapGate',
     'SqrtXGate',

--- a/bqskit/ir/gates/constant/__init__.py
+++ b/bqskit/ir/gates/constant/__init__.py
@@ -8,6 +8,7 @@ from bqskit.ir.gates.constant.clock import ClockGate
 from bqskit.ir.gates.constant.cpi import CPIGate
 from bqskit.ir.gates.constant.cs import CSGate
 from bqskit.ir.gates.constant.csum import CSUMGate
+from bqskit.ir.gates.constant.csumd import CSUMDGate
 from bqskit.ir.gates.constant.ct import CTGate
 from bqskit.ir.gates.constant.cx import CNOTGate
 from bqskit.ir.gates.constant.cx import CXGate
@@ -47,6 +48,7 @@ __all__ = [
     'CPIGate',
     'CSGate',
     'CSUMGate',
+    'CSUMDGate',
     'CTGate',
     'CNOTGate',
     'CXGate',

--- a/bqskit/ir/gates/constant/__init__.py
+++ b/bqskit/ir/gates/constant/__init__.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from bqskit.ir.gates.constant.ccx import CCXGate
 from bqskit.ir.gates.constant.ccx import ToffoliGate
-from bqskit.ir.gates.constant.clock import ClockGate
 from bqskit.ir.gates.constant.ch import CHGate
+from bqskit.ir.gates.constant.clock import ClockGate
 from bqskit.ir.gates.constant.cpi import CPIGate
 from bqskit.ir.gates.constant.cs import CSGate
 from bqskit.ir.gates.constant.csum import CSUMGate

--- a/bqskit/ir/gates/constant/__init__.py
+++ b/bqskit/ir/gates/constant/__init__.py
@@ -27,6 +27,7 @@ from bqskit.ir.gates.constant.shift import ShiftGate
 from bqskit.ir.gates.constant.sqrtcnot import SqrtCNOTGate
 from bqskit.ir.gates.constant.sqrtiswap import SqrtISwapGate
 from bqskit.ir.gates.constant.swap import SwapGate
+from bqskit.ir.gates.constant.subswap import SubSwapGate
 from bqskit.ir.gates.constant.sx import SqrtXGate
 from bqskit.ir.gates.constant.sx import SXGate
 from bqskit.ir.gates.constant.sycamore import SycamoreGate
@@ -66,6 +67,7 @@ __all__ = [
     'ShiftGate',
     'SqrtCNOTGate',
     'SwapGate',
+    'SubSwapGate',
     'SqrtXGate',
     'SqrtISwapGate',
     'SXGate',

--- a/bqskit/ir/gates/constant/clock.py
+++ b/bqskit/ir/gates/constant/clock.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import numpy as np
 
-from bqskit.ir.gates.constantgate import ConstantGate
 from bqskit.ir.gates.quditgate import QuditGate
 from bqskit.qis.unitary.unitary import RealVector
 from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix

--- a/bqskit/ir/gates/constant/clock.py
+++ b/bqskit/ir/gates/constant/clock.py
@@ -1,0 +1,40 @@
+"""This module implements the ClockGate."""
+from __future__ import annotations
+
+from bqskit.ir.gates.constantgate import ConstantGate
+from bqskit.ir.gates.quditgate import QuditGate
+from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
+from bqskit.qis.unitary.unitary import RealVector
+import numpy as np
+
+
+class ClockGate(QuditGate):
+    """
+    The one-qudit clock (Z) gate.
+    This is a Weyl-Heisenberg gate.
+
+    The clock gate is given by the following formula:
+
+    .. math::
+        \\begin{equation}
+            Z = \\sum_a \\exp(2\\pi ia/d) |a><a|
+        \\end{equation}
+
+    where d is the number of levels (2 levels is a qubit, 
+    3 levels is a qutrit, etc.)
+    """
+
+    _num_qudits = 1
+    _num_params = 0
+
+    def __init__(self,num_levels):
+        self.num_levels = num_levels
+
+    def get_unitary(self, params: RealVector = []) -> UnitaryMatrix:
+        """Return the unitary for this gate, see :class:`Unitary` for more."""
+
+        matrix = np.zeros(self.num_levels, dtype = complex)
+        for i in range(self.num_levels):
+            matrix[i] = np.exp(2j*np.pi*i/self.num_levels)
+        u_mat = UnitaryMatrix(np.diag(matrix), self.radixes)
+        return u_mat

--- a/bqskit/ir/gates/constant/clock.py
+++ b/bqskit/ir/gates/constant/clock.py
@@ -30,7 +30,7 @@ class ClockGate(QuditGate):
     _num_qudits = 1
     _num_params = 0
 
-    def __init__(self, num_levels):
+    def __init__(self, num_levels: int):
         self.num_levels = num_levels
 
     def get_unitary(self, params: RealVector = []) -> UnitaryMatrix:

--- a/bqskit/ir/gates/constant/clock.py
+++ b/bqskit/ir/gates/constant/clock.py
@@ -21,6 +21,10 @@ class ClockGate(QuditGate):
 
     where d is the number of levels (2 levels is a qubit,
     3 levels is a qutrit, etc.)
+
+    __init__() arguments:
+        num_levels : int
+            Number of levels in each quantum object.
     """
 
     _num_qudits = 1
@@ -32,8 +36,8 @@ class ClockGate(QuditGate):
     def get_unitary(self, params: RealVector = []) -> UnitaryMatrix:
         """Return the unitary for this gate, see :class:`Unitary` for more."""
 
-        matrix = np.zeros(self.num_levels, dtype=complex)
+        diags = np.zeros(self.num_levels, dtype=complex)
         for i in range(self.num_levels):
-            matrix[i] = np.exp(2j * np.pi * i / self.num_levels)
-        u_mat = UnitaryMatrix(np.diag(matrix), self.radixes)
+            diags[i] = np.exp(2j * np.pi * i / self.num_levels)
+        u_mat = UnitaryMatrix(np.diag(diags), self.radixes)
         return u_mat

--- a/bqskit/ir/gates/constant/clock.py
+++ b/bqskit/ir/gates/constant/clock.py
@@ -1,17 +1,17 @@
 """This module implements the ClockGate."""
 from __future__ import annotations
 
+import numpy as np
+
 from bqskit.ir.gates.constantgate import ConstantGate
 from bqskit.ir.gates.quditgate import QuditGate
-from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
 from bqskit.qis.unitary.unitary import RealVector
-import numpy as np
+from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
 
 
 class ClockGate(QuditGate):
     """
-    The one-qudit clock (Z) gate.
-    This is a Weyl-Heisenberg gate.
+    The one-qudit clock (Z) gate. This is a Weyl-Heisenberg gate.
 
     The clock gate is given by the following formula:
 
@@ -20,21 +20,21 @@ class ClockGate(QuditGate):
             Z = \\sum_a \\exp(2\\pi ia/d) |a><a|
         \\end{equation}
 
-    where d is the number of levels (2 levels is a qubit, 
+    where d is the number of levels (2 levels is a qubit,
     3 levels is a qutrit, etc.)
     """
 
     _num_qudits = 1
     _num_params = 0
 
-    def __init__(self,num_levels):
+    def __init__(self, num_levels):
         self.num_levels = num_levels
 
     def get_unitary(self, params: RealVector = []) -> UnitaryMatrix:
         """Return the unitary for this gate, see :class:`Unitary` for more."""
 
-        matrix = np.zeros(self.num_levels, dtype = complex)
+        matrix = np.zeros(self.num_levels, dtype=complex)
         for i in range(self.num_levels):
-            matrix[i] = np.exp(2j*np.pi*i/self.num_levels)
+            matrix[i] = np.exp(2j * np.pi * i / self.num_levels)
         u_mat = UnitaryMatrix(np.diag(matrix), self.radixes)
         return u_mat

--- a/bqskit/ir/gates/constant/csum.py
+++ b/bqskit/ir/gates/constant/csum.py
@@ -8,8 +8,8 @@ from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
 
 class CSUMGate(ConstantGate, QutritGate):
     """
-    The two-qutrit Conditional-SUM gate.
-    Note that this is equivalent to `CSUMDGate(num_levels=3).`
+    The two-qutrit Conditional-SUM gate. Note that this is equivalent to
+    `CSUMDGate(num_levels=3).`
 
     The CSUM gate is given by the following unitary:
 
@@ -23,8 +23,8 @@ class CSUMGate(ConstantGate, QutritGate):
         0 & 0 & 0 & 1 & 0 & 0 & 0 & 0 & 0 \\\\
         0 & 0 & 0 & 0 & 1 & 0 & 0 & 0 & 0 \\\\
         0 & 0 & 0 & 0 & 0 & 0 & 0 & 1 & 0 \\\\
-        0 & 0 & 0 & 0 & 0 & 0 & 1 & 0 & 0 \\\\
         0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 & 1 \\\\
+        0 & 0 & 0 & 0 & 0 & 0 & 1 & 0 & 0 \\\\
         \\end{pmatrix}
     """
 
@@ -38,7 +38,7 @@ class CSUMGate(ConstantGate, QutritGate):
             [0, 0, 0, 1, 0, 0, 0, 0, 0],
             [0, 0, 0, 0, 1, 0, 0, 0, 0],
             [0, 0, 0, 0, 0, 0, 0, 1, 0],
-            [0, 0, 0, 0, 0, 0, 1, 0, 0],
             [0, 0, 0, 0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0, 1, 0, 0],
         ],
     )

--- a/bqskit/ir/gates/constant/csum.py
+++ b/bqskit/ir/gates/constant/csum.py
@@ -9,6 +9,7 @@ from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
 class CSUMGate(ConstantGate, QutritGate):
     """
     The two-qutrit Conditional-SUM gate.
+    Note that this is equivalent to `CSUMDGate(num_levels=3).`
 
     The CSUM gate is given by the following unitary:
 

--- a/bqskit/ir/gates/constant/csumd.py
+++ b/bqskit/ir/gates/constant/csumd.py
@@ -40,9 +40,9 @@ class CSUMDGate(QuditGate):
         jval = 0
         matrix = np.zeros([self.num_levels**2, self.num_levels**2])
         for i, col in enumerate(matrix.T):
-            col[self.num_levels*jval + ((ival + jval) % self.num_levels)] = 1
+            col[self.num_levels * jval + ((ival + jval) % self.num_levels)] = 1
             matrix[:, i] = col
-            if ival == self.num_levels-1:
+            if ival == self.num_levels - 1:
                 ival = 0
                 jval += 1
             else:

--- a/bqskit/ir/gates/constant/csumd.py
+++ b/bqskit/ir/gates/constant/csumd.py
@@ -30,7 +30,7 @@ class CSUMDGate(QuditGate):
     _num_qudits = 2
     _num_params = 0
 
-    def __init__(self, num_levels):
+    def __init__(self, num_levels: int):
         self.num_levels = num_levels
 
     def get_unitary(self, params: RealVector = []) -> UnitaryMatrix:

--- a/bqskit/ir/gates/constant/hd.py
+++ b/bqskit/ir/gates/constant/hd.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import numpy as np
 
-from bqskit.ir.gates.constantgate import ConstantGate
 from bqskit.ir.gates.quditgate import QuditGate
 from bqskit.qis.unitary.unitary import RealVector
 from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix

--- a/bqskit/ir/gates/constant/hd.py
+++ b/bqskit/ir/gates/constant/hd.py
@@ -1,17 +1,17 @@
 """This module implements the HDGate."""
 from __future__ import annotations
 
+import numpy as np
+
 from bqskit.ir.gates.constantgate import ConstantGate
 from bqskit.ir.gates.quditgate import QuditGate
-from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
 from bqskit.qis.unitary.unitary import RealVector
-import numpy as np
+from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
 
 
 class HDGate(QuditGate):
     """
-    The one-qudit Hadamard gate.
-    This is a Clifford gate.
+    The one-qudit Hadamard gate. This is a Clifford gate.
 
     The clock gate is given by the following formula:
 
@@ -22,24 +22,26 @@ class HDGate(QuditGate):
 
     where
     .. math:: \\omega = \\exp(2\\pi*i/d)
-    and d is the number of levels (2 levels is a qubit, 
+    and d is the number of levels (2 levels is a qubit,
     3 levels is a qutrit, etc.)
     """
 
     _num_qudits = 1
     _num_params = 0
 
-    def __init__(self,num_levels):
+    def __init__(self, num_levels):
         self.num_levels = num_levels
 
     def get_unitary(self, params: RealVector = []) -> UnitaryMatrix:
         """Return the unitary for this gate, see :class:`Unitary` for more."""
 
-        matrix = np.zeros([self.num_levels, self.num_levels], dtype = complex)
-        omega = np.exp(2j*np.pi/self.num_levels)
+        matrix = np.zeros([self.num_levels, self.num_levels], dtype=complex)
+        omega = np.exp(2j * np.pi / self.num_levels)
         for i in range(self.num_levels):
             for j in range(i, self.num_levels):
-                matrix[i,j] = omega**(i*j)
-                matrix[j,i] = omega**(i*j)
-        u_mat = UnitaryMatrix(matrix*1/np.sqrt(self.num_levels), self.radixes)
+                matrix[i, j] = omega**(i * j)
+                matrix[j, i] = omega**(i * j)
+        u_mat = UnitaryMatrix(
+            matrix * 1 / np.sqrt(self.num_levels), self.radixes,
+        )
         return u_mat

--- a/bqskit/ir/gates/constant/hd.py
+++ b/bqskit/ir/gates/constant/hd.py
@@ -32,7 +32,7 @@ class HDGate(QuditGate):
     _num_qudits = 1
     _num_params = 0
 
-    def __init__(self, num_levels):
+    def __init__(self, num_levels: int):
         self.num_levels = num_levels
 
     def get_unitary(self, params: RealVector = []) -> UnitaryMatrix:

--- a/bqskit/ir/gates/constant/hd.py
+++ b/bqskit/ir/gates/constant/hd.py
@@ -1,0 +1,45 @@
+"""This module implements the HDGate."""
+from __future__ import annotations
+
+from bqskit.ir.gates.constantgate import ConstantGate
+from bqskit.ir.gates.quditgate import QuditGate
+from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
+from bqskit.qis.unitary.unitary import RealVector
+import numpy as np
+
+
+class HDGate(QuditGate):
+    """
+    The one-qudit Hadamard gate.
+    This is a Clifford gate.
+
+    The clock gate is given by the following formula:
+
+    .. math::
+        \\begin{equation}
+            H_d = 1/\\sqrt(d) \\sum_{ij} \\omega_d^{ij} |i >< j|
+        \\end{equation}
+
+    where
+    .. math:: \\omega = \\exp(2\\pi*i/d)
+    and d is the number of levels (2 levels is a qubit, 
+    3 levels is a qutrit, etc.)
+    """
+
+    _num_qudits = 1
+    _num_params = 0
+
+    def __init__(self,num_levels):
+        self.num_levels = num_levels
+
+    def get_unitary(self, params: RealVector = []) -> UnitaryMatrix:
+        """Return the unitary for this gate, see :class:`Unitary` for more."""
+
+        matrix = np.zeros([self.num_levels, self.num_levels], dtype = complex)
+        omega = np.exp(2j*np.pi/self.num_levels)
+        for i in range(self.num_levels):
+            for j in range(i, self.num_levels):
+                matrix[i,j] = omega**(i*j)
+                matrix[j,i] = omega**(i*j)
+        u_mat = UnitaryMatrix(matrix*1/np.sqrt(self.num_levels), self.radixes)
+        return u_mat

--- a/bqskit/ir/gates/constant/pd.py
+++ b/bqskit/ir/gates/constant/pd.py
@@ -13,7 +13,7 @@ class PDGate(QuditGate):
     The one-qudit P[i] gate.
 
     The clock gate is given by the following formula,
-    taken from https://pubs.aip.org/aip/jmp/article/56/3/032202/763827/Universal-quantum-computation-with-metaplectic
+    taken from https://pubs.aip.org/aip/jmp/article/56/3/032202/763827/Universal-quantum-computation-with-metaplectic #noqa
 
     .. math::
         \\begin{equation}

--- a/bqskit/ir/gates/constant/pd.py
+++ b/bqskit/ir/gates/constant/pd.py
@@ -35,7 +35,7 @@ class PDGate(QuditGate):
     _num_qudits = 1
     _num_params = 0
 
-    def __init__(self, num_levels, ind):
+    def __init__(self, num_levels: int, ind: int):
         self.num_levels = num_levels
         if ind > num_levels:
             raise ValueError(

--- a/bqskit/ir/gates/constant/pd.py
+++ b/bqskit/ir/gates/constant/pd.py
@@ -13,7 +13,7 @@ class PDGate(QuditGate):
     The one-qudit P[i] gate.
 
     The clock gate is given by the following formula,
-    taken from https://pubs.aip.org/aip/jmp/article/56/3/032202/763827/Universal-quantum-computation-with-metaplectic #noqa
+    taken from https://bit.ly/3MM6jou
 
     .. math::
         \\begin{equation}

--- a/bqskit/ir/gates/constant/pd.py
+++ b/bqskit/ir/gates/constant/pd.py
@@ -1,4 +1,4 @@
-"""This module implements the HDGate."""
+"""This module implements the PDGate."""
 from __future__ import annotations
 
 import numpy as np
@@ -8,15 +8,16 @@ from bqskit.qis.unitary.unitary import RealVector
 from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
 
 
-class HDGate(QuditGate):
+class PDGate(QuditGate):
     """
-    The one-qudit Hadamard gate. This is a Clifford gate.
+    The one-qudit P[i] gate.
 
-    The clock gate is given by the following formula:
+    The clock gate is given by the following formula,
+    taken from https://pubs.aip.org/aip/jmp/article/56/3/032202/763827/Universal-quantum-computation-with-metaplectic
 
     .. math::
         \\begin{equation}
-            H_d = 1/\\sqrt(d) \\sum_{ij} \\omega_d^{ij} |i >< j|
+            P[i]_d = \\sum_{j} (-\\omega**2)^{\\delta_{ij}} |j><j|
         \\end{equation}
 
     where
@@ -27,24 +28,28 @@ class HDGate(QuditGate):
     __init__() arguments:
         num_levels : int
             Number of levels in each quantum object.
+        ind: int
+            The level on which to apply rotation (see above equation).
     """
 
     _num_qudits = 1
     _num_params = 0
 
-    def __init__(self, num_levels):
+    def __init__(self, num_levels, ind):
         self.num_levels = num_levels
+        if ind > num_levels:
+            raise ValueError('PDGate index must be equal or less to the number of levels.')
+        self.ind = ind
 
     def get_unitary(self, params: RealVector = []) -> UnitaryMatrix:
         """Return the unitary for this gate, see :class:`Unitary` for more."""
 
-        matrix = np.zeros([self.num_levels, self.num_levels], dtype=complex)
+        diags = np.zeros(self.num_levels, dtype=complex)
         omega = np.exp(2j * np.pi / self.num_levels)
         for i in range(self.num_levels):
-            for j in range(i, self.num_levels):
-                matrix[i, j] = omega**(i * j)
-                matrix[j, i] = omega**(i * j)
-        u_mat = UnitaryMatrix(
-            matrix * 1 / np.sqrt(self.num_levels), self.radixes,
-        )
+            if i == self.ind:
+                diags[i] = -omega**2
+            else:
+                diags[i] = 1
+        u_mat = UnitaryMatrix(np.diag(diags), self.radixes)
         return u_mat

--- a/bqskit/ir/gates/constant/pd.py
+++ b/bqskit/ir/gates/constant/pd.py
@@ -27,7 +27,7 @@ class PDGate(QuditGate):
 
     __init__() arguments:
         num_levels : int
-            Number of levels in each quantum object.
+            Number of levels in each qudit (d).
         ind: int
             The level on which to apply rotation (see above equation).
     """

--- a/bqskit/ir/gates/constant/shift.py
+++ b/bqskit/ir/gates/constant/shift.py
@@ -27,7 +27,7 @@ class ShiftGate(QuditGate):
     _num_qudits = 1
     _num_params = 0
 
-    def __init__(self, num_levels):
+    def __init__(self, num_levels: int):
         self.num_levels = num_levels
 
     def get_unitary(self, params: RealVector = []) -> UnitaryMatrix:

--- a/bqskit/ir/gates/constant/shift.py
+++ b/bqskit/ir/gates/constant/shift.py
@@ -18,6 +18,10 @@ class ShiftGate(QuditGate):
 
     where d is the number of levels (2 levels is a qubit,
     3 levels is a qutrit, etc.)
+
+    __init__() arguments:
+        num_levels : int
+            Number of levels in each quantum object.
     """
 
     _num_qudits = 1

--- a/bqskit/ir/gates/constant/shift.py
+++ b/bqskit/ir/gates/constant/shift.py
@@ -1,40 +1,40 @@
 """This module implements the ShiftGate."""
 from __future__ import annotations
 
-from bqskit.ir.gates.quditgate import QuditGate
-from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
-from bqskit.qis.unitary.unitary import RealVector
 import numpy as np
+
+from bqskit.ir.gates.quditgate import QuditGate
+from bqskit.qis.unitary.unitary import RealVector
+from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
 
 
 class ShiftGate(QuditGate):
-    """
-    The one-qudit shift (X) gate.
-    This is a Weyl-Heisenberg gate.
+    r"""
+    The one-qudit shift (X) gate. This is a Weyl-Heisenberg gate.
 
     The shift gate is given by the following formula:
 
     X = \sum_a |a + 1 mod d ><a|
 
-    where d is the number of levels (2 levels is a qubit, 
+    where d is the number of levels (2 levels is a qubit,
     3 levels is a qutrit, etc.)
     """
 
     _num_qudits = 1
     _num_params = 0
 
-    def __init__(self,num_levels):
+    def __init__(self, num_levels):
         self.num_levels = num_levels
 
     def get_unitary(self, params: RealVector = []) -> UnitaryMatrix:
         """Return the unitary for this gate, see :class:`Unitary` for more."""
 
-        matrix = np.zeros([self.num_levels, self.num_levels], dtype = complex)
-        for i,col in enumerate(matrix.T):
-            if i+1 >= self.num_levels:
+        matrix = np.zeros([self.num_levels, self.num_levels], dtype=complex)
+        for i, col in enumerate(matrix.T):
+            if i + 1 >= self.num_levels:
                 col[0] = 1
             else:
-                col[i+1] = 1
-            matrix[:,i] = col
+                col[i + 1] = 1
+            matrix[:, i] = col
         u_mat = UnitaryMatrix(matrix, self.radixes)
         return u_mat

--- a/bqskit/ir/gates/constant/shift.py
+++ b/bqskit/ir/gates/constant/shift.py
@@ -21,7 +21,7 @@ class ShiftGate(QuditGate):
 
     __init__() arguments:
         num_levels : int
-            Number of levels in each quantum object.
+            Number of levels in each qudit (d).
     """
 
     _num_qudits = 1

--- a/bqskit/ir/gates/constant/shift.py
+++ b/bqskit/ir/gates/constant/shift.py
@@ -1,0 +1,40 @@
+"""This module implements the ShiftGate."""
+from __future__ import annotations
+
+from bqskit.ir.gates.quditgate import QuditGate
+from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
+from bqskit.qis.unitary.unitary import RealVector
+import numpy as np
+
+
+class ShiftGate(QuditGate):
+    """
+    The one-qudit shift (X) gate.
+    This is a Weyl-Heisenberg gate.
+
+    The shift gate is given by the following formula:
+
+    X = \sum_a |a + 1 mod d ><a|
+
+    where d is the number of levels (2 levels is a qubit, 
+    3 levels is a qutrit, etc.)
+    """
+
+    _num_qudits = 1
+    _num_params = 0
+
+    def __init__(self,num_levels):
+        self.num_levels = num_levels
+
+    def get_unitary(self, params: RealVector = []) -> UnitaryMatrix:
+        """Return the unitary for this gate, see :class:`Unitary` for more."""
+
+        matrix = np.zeros([self.num_levels, self.num_levels], dtype = complex)
+        for i,col in enumerate(matrix.T):
+            if i+1 >= self.num_levels:
+                col[0] = 1
+            else:
+                col[i+1] = 1
+            matrix[:,i] = col
+        u_mat = UnitaryMatrix(matrix, self.radixes)
+        return u_mat

--- a/bqskit/ir/gates/constant/subswap.py
+++ b/bqskit/ir/gates/constant/subswap.py
@@ -1,0 +1,88 @@
+"""This module implements the SubSwapGate."""
+from __future__ import annotations
+
+import numpy as np
+
+from bqskit.ir.gates.quditgate import QuditGate
+from bqskit.qis.unitary.unitary import RealVector
+from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
+
+
+class SubSwapGate(QuditGate):
+    r"""
+    The two-qudit subspace SWAP gate.
+
+    The subspace SWAP gate swaps between "qudit-levels" 
+    on a two-qudit gate. 
+    For example, a |01> to |20> swap would be the identity 
+    with the |01> row and |20> rows swapped.
+
+    __init__() arguments:
+        num_levels : int
+            Number of levels in each qudit (d).
+        qudit_levels : str
+            The qudit levels that should be swapped, separated by a comma.
+            Example: "0,1;2,0" to swap |01> to |20>
+    """
+
+    _num_qudits = 2
+    _num_params = 0
+
+    def __init__(self, num_levels: int, qudit_levels: str):
+        self.num_levels = num_levels
+        level1, level2 = self.convert_string_to_lists(qudit_levels)
+        self.qudit_level1 = level1
+        self.qudit_level2 = level2
+
+    def get_unitary(self, params: RealVector = []) -> UnitaryMatrix:
+        """Return the unitary for this gate, see :class:`Unitary` for more."""
+
+        # qubit level indices |ival,jval>
+        ival = 0
+        jval = 0
+
+        # unitary matrix
+        matrix = np.zeros([self.num_levels**2, self.num_levels**2])
+
+        # building the matrix column by column
+        for i, col in enumerate(matrix.T):
+
+            # checking to see if the column is one that should be swapped
+            # and if so, doing the swap
+            if ival == self.qudit_level1[0] and jval == self.qudit_level1[1]:
+                iswap = self.qudit_level2[0]
+                jswap = self.qudit_level2[1]
+                pos = self.num_levels * jswap + iswap
+            elif ival == self.qudit_level2[0] and jval == self.qudit_level2[1]:
+                iswap = self.qudit_level1[0]
+                jswap = self.qudit_level1[1]
+                pos = self.num_levels * jswap + iswap
+            else:
+                pos = self.num_levels * jval + ival
+            col[pos] = 1
+            matrix[:, i] = col
+
+            # updating ival and jval 
+            if ival == self.num_levels - 1:
+                ival = 0
+                jval += 1
+            else:
+                ival += 1
+        u_mat = UnitaryMatrix(matrix, self.radixes)
+        return u_mat
+    
+    @staticmethod
+    def convert_string_to_lists(string):
+        split_values = string.split(';')
+        list1 = []
+        list2 = []
+        for i, values in enumerate(split_values):
+            numbers = values.split(',')
+            if i == 0:
+                list1.append(int(numbers[1]))
+                list1.append(int(numbers[0]))
+            else:
+                list2.append(int(numbers[1]))
+                list2.append(int(numbers[0]))
+        return list1, list2
+

--- a/bqskit/ir/gates/constant/subswap.py
+++ b/bqskit/ir/gates/constant/subswap.py
@@ -12,9 +12,9 @@ class SubSwapGate(QuditGate):
     r"""
     The two-qudit subspace SWAP gate.
 
-    The subspace SWAP gate swaps between "qudit-levels" 
-    on a two-qudit gate. 
-    For example, a |01> to |20> swap would be the identity 
+    The subspace SWAP gate swaps between "qudit-levels"
+    on a two-qudit gate.
+    For example, a |01> to |20> swap would be the identity
     with the |01> row and |20> rows swapped.
 
     __init__() arguments:
@@ -62,7 +62,7 @@ class SubSwapGate(QuditGate):
             col[pos] = 1
             matrix[:, i] = col
 
-            # updating ival and jval 
+            # updating ival and jval
             if ival == self.num_levels - 1:
                 ival = 0
                 jval += 1
@@ -70,12 +70,12 @@ class SubSwapGate(QuditGate):
                 ival += 1
         u_mat = UnitaryMatrix(matrix, self.radixes)
         return u_mat
-    
+
     @staticmethod
-    def convert_string_to_lists(string):
+    def convert_string_to_lists(string: str) -> tuple[list[int], list[int]]:
         split_values = string.split(';')
-        list1 = []
-        list2 = []
+        list1: list[int] = []
+        list2: list[int] = []
         for i, values in enumerate(split_values):
             numbers = values.split(',')
             if i == 0:
@@ -85,4 +85,3 @@ class SubSwapGate(QuditGate):
                 list2.append(int(numbers[1]))
                 list2.append(int(numbers[0]))
         return list1, list2
-

--- a/bqskit/ir/gates/quditgate.py
+++ b/bqskit/ir/gates/quditgate.py
@@ -20,5 +20,5 @@ class QuditGate(Gate):
         return getattr(self, '_num_levels')
 
     @num_levels.setter
-    def num_levels(self, value: int):
+    def num_levels(self, value: int) -> None:
         self._num_levels = value

--- a/bqskit/ir/gates/quditgate.py
+++ b/bqskit/ir/gates/quditgate.py
@@ -20,5 +20,5 @@ class QuditGate(Gate):
         return getattr(self, '_num_levels')
 
     @num_levels.setter
-    def num_levels(self, value):
+    def num_levels(self, value: int):
         self._num_levels = value

--- a/bqskit/ir/gates/quditgate.py
+++ b/bqskit/ir/gates/quditgate.py
@@ -1,0 +1,24 @@
+"""This module implements the QuditGate base class."""
+from __future__ import annotations
+
+from bqskit.ir.gate import Gate
+
+
+class QuditGate(Gate):
+    """A gate that acts on qudits."""
+
+    _num_levels: int
+
+    @property
+    def radixes(self) -> tuple[int, ...]:
+        """The number of orthogonal states for each qudit."""
+        return tuple([self.num_levels] * self.num_qudits)
+
+    @property
+    def num_levels(self) -> int:
+        """The number of levels in each qudit."""
+        return getattr(self, '_num_levels')
+
+    @num_levels.setter
+    def num_levels(self, value):
+        self._num_levels = value


### PR DESCRIPTION
closes #153 as part of the UnitaryHack 2023 event. 

**NEW IMPLEMENTATIONS**:
1. a generic `QuditGate` base class (following the examples of `QubitGate` and `QutritGate`)
2. single-qudit Weyl-Heisenberg gates (`ShiftGate` and `ClockGate`)
3. a (Clifford) Hadamard gate `HDGate` (for an *n*-level qudit system)
4. qudit phase gates `PDGate` (related to $\sigma_z$ )
5. a generic (Clifford) CSUM gate `CSUMDGate` (following the [existing implementation in bqskit](https://github.com/BQSKit/bqskit/blob/master/bqskit/ir/gates/constant/csum.py), but generalized to qudits instead of just qutrits)
6. subspace swap gate `SubSwapGate`

Together, the generic `CSUMDGate`, `HDGate`, and `PDGate` s form a universal qudit gate set (proved in [this paper](https://pubs.aip.org/aip/jmp/article/56/3/032202/763827/Universal-quantum-computation-with-metaplectic)).

**FIXES**:
1. The existing `CSUMGate` had the wrong unitary representation (see screenshot directly below). I changed it to the correct unitary.

 <img width="931" alt="Screen Shot 2023-05-28 at 9 49 50 PM" src="https://github.com/BQSKit/bqskit/assets/74874354/b7c50a3c-1da0-4892-9e74-88748d84d2cb">

1. In #153, there were two other types of gates: subspace single-qudit gates, and subspace swaps. What is meant by "subspace" gates here? Does it refer to situations in which you have hybrid qubit-qudit systems?
3. Is my current workflow/placement of the new gates suitable? Since they are not parametrized, I put them in the `bqskit.ir.gates.constant` folder, but I don't use `ConstantGate` as a parent class. This is because the unitary matrix being implemented depends on the number of levels in the qudit (which is passed as an argument to the gate when it's called, and the unitary is built with a `get_unitary()` function). Is this a problem? Here is a screenshot of the code in practice.

<img width="923" alt="Screen Shot 2023-05-28 at 1 02 38 AM" src="https://github.com/BQSKit/bqskit/assets/74874354/67d9ff47-4143-417a-9ad0-c3d16f1de95c">
