### PR TITLE
Remove perform from tests

### DIFF
--- a/tests/ir/circuit/test_batch_replace.py
+++ b/tests/ir/circuit/test_batch_replace.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from random import randint
 
+from bqskit.compiler.compiler import Compiler
 from bqskit.ir.circuit import Circuit
 from bqskit.ir.gates.constant.cx import CNOTGate
 from bqskit.ir.operation import Operation
@@ -106,7 +107,7 @@ class TestBatchReplace:
             (3, 1),
         ) == op_5b
 
-    def test_random_batch_replace(self) -> None:
+    def test_random_batch_replace(self, compiler: Compiler) -> None:
         num_gates = 200
         num_q = 10
 
@@ -118,7 +119,7 @@ class TestBatchReplace:
                 b = (b + 1) % num_q
             circ.append_gate(CNOTGate(), [a, b])
 
-        circ.perform(ScanPartitioner(2))
+        circ = compiler.compile(circ, [ScanPartitioner(2)])
 
         points = []
         ops = []

--- a/tests/passes/mapping/test_apply.py
+++ b/tests/passes/mapping/test_apply.py
@@ -8,10 +8,9 @@ from bqskit.passes import GreedyPlacementPass
 from bqskit.passes import SetModelPass
 
 
-def test_apply_placement(r3_qubit_circuit: Circuit) -> None:
+def test_apply_placement(r3_qubit_circuit: Circuit, compiler: Compiler) -> None:
     model = MachineModel(6, [(0, 1), (1, 2), (2, 3), (2, 4), (2, 5), (3, 5)])
     workflow = [SetModelPass(model), GreedyPlacementPass(), ApplyPlacement()]
-    with Compiler() as compiler:
-        out_circuit = compiler.compile(r3_qubit_circuit, workflow)
-        assert out_circuit.num_qudits == 6
-        assert out_circuit.active_qudits == [2, 3, 5]
+    out_circuit = compiler.compile(r3_qubit_circuit, workflow)
+    assert out_circuit.num_qudits == 6
+    assert out_circuit.active_qudits == [2, 3, 5]

--- a/tests/passes/mapping/test_sabre.py
+++ b/tests/passes/mapping/test_sabre.py
@@ -13,7 +13,7 @@ from bqskit.qis import PermutationMatrix
 from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
 
 
-def test_simple() -> None:
+def test_simple(compiler: Compiler) -> None:
     cg = (0, 1), (0, 2), (0, 3), (0, 4), (0, 5), (0, 6), (0, 7)
     model = MachineModel(8, cg)
     circuit = Circuit(5)
@@ -40,11 +40,10 @@ def test_simple() -> None:
         GeneralizedSabreRoutingPass(),
     ]
 
-    with Compiler() as compiler:
-        cc, data = compiler.compile(circuit, workflow, True)
-        pi = data['initial_mapping']
-        pf = data['final_mapping']
-        PI = PermutationMatrix.from_qubit_location(5, pi)
-        PF = PermutationMatrix.from_qubit_location(5, pf)
-        assert cc.get_unitary().get_distance_from(PF.T @ in_utry @ PI) < 1e-7
-        assert all(e in cg for e in cc.coupling_graph)
+    cc, data = compiler.compile(circuit, workflow, True)
+    pi = data['initial_mapping']
+    pf = data['final_mapping']
+    PI = PermutationMatrix.from_qubit_location(5, pi)
+    PF = PermutationMatrix.from_qubit_location(5, pf)
+    assert cc.get_unitary().get_distance_from(PF.T @ in_utry @ PI) < 1e-7
+    assert all(e in cg for e in cc.coupling_graph)

--- a/tests/passes/partitioning/test_barrier.py
+++ b/tests/passes/partitioning/test_barrier.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from bqskit import compile
+from bqskit.compiler.compiler import Compiler
 from bqskit.ir.circuit import Circuit
 from bqskit.ir.gates import BarrierPlaceholder
 from bqskit.ir.gates import CircuitGate
@@ -9,12 +10,12 @@ from bqskit.ir.gates import U3Gate
 from bqskit.passes.partitioning.quick import QuickPartitioner
 
 
-def test_barrier_still_there_after_partitioning() -> None:
+def test_barrier_still_there_after_partitioning(compiler: Compiler) -> None:
     circuit = Circuit(2)
     circuit.append_gate(CXGate(), (0, 1))
     circuit.append_gate(BarrierPlaceholder(2), (0, 1))
     circuit.append_gate(CXGate(), (0, 1))
-    circuit.perform(QuickPartitioner(3))
+    circuit = compiler.compile(circuit, [QuickPartitioner(3)])
     assert circuit.num_operations == 3
     assert isinstance(circuit[0, 0].gate, CircuitGate)
     assert isinstance(circuit[1, 0].gate, BarrierPlaceholder)
@@ -25,14 +26,16 @@ def test_barrier_still_there_after_partitioning() -> None:
     assert isinstance(circuit[2, 0].gate, CXGate)
 
 
-def test_barrier_stop_partitioning_across_some_circuit() -> None:
+def test_barrier_stop_partitioning_across_some_circuit(
+        compiler: Compiler,
+) -> None:
     circuit = Circuit(4)
     circuit.append_gate(CXGate(), (0, 1))
     circuit.append_gate(BarrierPlaceholder(2), (0, 1))
     circuit.append_gate(CXGate(), (0, 1))
     circuit.append_gate(CXGate(), (2, 3))
     circuit.append_gate(CXGate(), (2, 3))
-    circuit.perform(QuickPartitioner(2))
+    circuit = compiler.compile(circuit, [QuickPartitioner(2)])
     assert circuit.num_operations == 4
 
 

--- a/tests/passes/partitioning/test_cluster.py
+++ b/tests/passes/partitioning/test_cluster.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+from bqskit.compiler.compiler import Compiler
 from bqskit.ir.circuit import Circuit
 from bqskit.ir.gates import CircuitGate
 from bqskit.passes.partitioning.cluster import ClusteringPartitioner
 
 
 class TestClusteringPartitioner:
-    def test_run_r6(self, r6_qudit_circuit: Circuit) -> None:
+    def test_run_r6(
+        self, r6_qudit_circuit: Circuit,
+        compiler: Compiler,
+    ) -> None:
         utry = r6_qudit_circuit.get_unitary()
-        r6_qudit_circuit.perform(ClusteringPartitioner(3, 2))
+        r6_qudit_circuit = compiler.compile(
+            r6_qudit_circuit, [ClusteringPartitioner(3, 2)],
+        )
 
         assert any(
             isinstance(op.gate, CircuitGate)

--- a/tests/passes/partitioning/test_quick.py
+++ b/tests/passes/partitioning/test_quick.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from bqskit.compiler.compiler import Compiler
 from bqskit.ir.circuit import Circuit
 from bqskit.ir.gates import CircuitGate
 from bqskit.ir.gates.constant.cx import CNOTGate
@@ -9,9 +10,14 @@ from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
 
 
 class TestQuickPartitioner:
-    def test_run_r6(self, r6_qudit_circuit: Circuit) -> None:
+    def test_run_r6(
+        self, r6_qudit_circuit: Circuit,
+        compiler: Compiler,
+    ) -> None:
         utry = r6_qudit_circuit.get_unitary()
-        r6_qudit_circuit.perform(QuickPartitioner(3))
+        r6_qudit_circuit = compiler.compile(
+            r6_qudit_circuit, [QuickPartitioner(3)],
+        )
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -22,7 +28,7 @@ class TestQuickPartitioner:
         for cycle_index in range(r6_qudit_circuit.num_cycles):
             assert not r6_qudit_circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_1(self) -> None:
+    def test_corner_case_1(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
 
         circuit.append_gate(
@@ -58,7 +64,7 @@ class TestQuickPartitioner:
         circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [1])
 
         utry = circuit.get_unitary()
-        circuit.perform(QuickPartitioner(3))
+        circuit = compiler.compile(circuit, [QuickPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -69,7 +75,7 @@ class TestQuickPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_2(self) -> None:
+    def test_corner_case_2(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
 
         circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [0])
@@ -113,7 +119,7 @@ class TestQuickPartitioner:
         circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [1])
 
         utry = circuit.get_unitary()
-        circuit.perform(QuickPartitioner(3))
+        circuit = compiler.compile(circuit, [QuickPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -124,7 +130,7 @@ class TestQuickPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_3(self) -> None:
+    def test_corner_case_3(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
         circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [0])
         circuit.append_gate(
@@ -165,7 +171,7 @@ class TestQuickPartitioner:
             ],
         )
         utry = circuit.get_unitary()
-        circuit.perform(QuickPartitioner(3))
+        circuit = compiler.compile(circuit, [QuickPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -176,7 +182,7 @@ class TestQuickPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_4(self) -> None:
+    def test_corner_case_4(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
 
         circuit.append_gate(
@@ -218,7 +224,7 @@ class TestQuickPartitioner:
         )
 
         utry = circuit.get_unitary()
-        circuit.perform(QuickPartitioner(3))
+        circuit = compiler.compile(circuit, [QuickPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -229,7 +235,7 @@ class TestQuickPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_5(self) -> None:
+    def test_corner_case_5(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
 
         circuit.append_gate(
@@ -280,7 +286,7 @@ class TestQuickPartitioner:
         circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [2])
 
         utry = circuit.get_unitary()
-        circuit.perform(QuickPartitioner(3))
+        circuit = compiler.compile(circuit, [QuickPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -291,7 +297,7 @@ class TestQuickPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_6(self) -> None:
+    def test_corner_case_6(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
 
         circuit.append_gate(
@@ -340,7 +346,7 @@ class TestQuickPartitioner:
         )
 
         utry = circuit.get_unitary()
-        circuit.perform(QuickPartitioner(3))
+        circuit = compiler.compile(circuit, [QuickPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -351,7 +357,7 @@ class TestQuickPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_7(self) -> None:
+    def test_corner_case_7(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
 
         circuit.append_gate(
@@ -414,7 +420,7 @@ class TestQuickPartitioner:
         )
 
         utry = circuit.get_unitary()
-        circuit.perform(QuickPartitioner(3))
+        circuit = compiler.compile(circuit, [QuickPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -425,7 +431,7 @@ class TestQuickPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_8(self) -> None:
+    def test_corner_case_8(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
 
         circuit.append_gate(
@@ -469,7 +475,7 @@ class TestQuickPartitioner:
         circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [4])
 
         utry = circuit.get_unitary()
-        circuit.perform(QuickPartitioner(3))
+        circuit = compiler.compile(circuit, [QuickPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -480,7 +486,7 @@ class TestQuickPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_9(self) -> None:
+    def test_corner_case_9(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
 
         circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [0])
@@ -522,7 +528,7 @@ class TestQuickPartitioner:
         )
 
         utry = circuit.get_unitary()
-        circuit.perform(QuickPartitioner(3))
+        circuit = compiler.compile(circuit, [QuickPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -533,7 +539,7 @@ class TestQuickPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_10(self) -> None:
+    def test_corner_case_10(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
 
         circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [0])
@@ -577,7 +583,7 @@ class TestQuickPartitioner:
         circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [3])
 
         utry = circuit.get_unitary()
-        circuit.perform(QuickPartitioner(3))
+        circuit = compiler.compile(circuit, [QuickPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -588,7 +594,7 @@ class TestQuickPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_11(self) -> None:
+    def test_corner_case_11(self, compiler: Compiler) -> None:
         circuit = Circuit(4)
 
         circuit.append_gate(CNOTGate(), (0, 1))
@@ -598,7 +604,7 @@ class TestQuickPartitioner:
         circuit.append_gate(CNOTGate(), (1, 2))
 
         utry = circuit.get_unitary()
-        circuit.perform(QuickPartitioner(3))
+        circuit = compiler.compile(circuit, [QuickPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)

--- a/tests/passes/partitioning/test_scan.py
+++ b/tests/passes/partitioning/test_scan.py
@@ -321,22 +321,49 @@ class TestScanPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_bigger_block(self, compiler: Compiler) -> None:
-        circuit = Circuit(6)
+    def test_bigger_block(self) -> None:
+        # In this test we need to create its own compiler as its state is
+        # unstable at the end of the test
+        with Compiler() as compiler:
+            circuit = Circuit(6)
 
-        circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [0])
-        circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [1])
-        circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [2])
-        circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [3])
-        circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [4])
-        circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [5])
+            circuit.append_gate(
+                ConstantUnitaryGate(
+                    UnitaryMatrix.random(1),
+                ), [0],
+            )
+            circuit.append_gate(
+                ConstantUnitaryGate(
+                    UnitaryMatrix.random(1),
+                ), [1],
+            )
+            circuit.append_gate(
+                ConstantUnitaryGate(
+                    UnitaryMatrix.random(1),
+                ), [2],
+            )
+            circuit.append_gate(
+                ConstantUnitaryGate(
+                    UnitaryMatrix.random(1),
+                ), [3],
+            )
+            circuit.append_gate(
+                ConstantUnitaryGate(
+                    UnitaryMatrix.random(1),
+                ), [4],
+            )
+            circuit.append_gate(
+                ConstantUnitaryGate(
+                    UnitaryMatrix.random(1),
+                ), [5],
+            )
 
-        circuit.append_gate(
-            ConstantUnitaryGate(
-                UnitaryMatrix.random(4),
-            ), [
-                1, 2, 3, 4,
-            ],
-        )
-        with pytest.raises(RuntimeError):
-            circuit = compiler.compile(circuit, [ScanPartitioner(3)])
+            circuit.append_gate(
+                ConstantUnitaryGate(
+                    UnitaryMatrix.random(4),
+                ), [
+                    1, 2, 3, 4,
+                ],
+            )
+            with pytest.raises(RuntimeError):
+                circuit = compiler.compile(circuit, [ScanPartitioner(3)])

--- a/tests/passes/partitioning/test_scan.py
+++ b/tests/passes/partitioning/test_scan.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from bqskit.compiler.compiler import Compiler
 from bqskit.ir.circuit import Circuit
 from bqskit.ir.gates import CircuitGate
 from bqskit.ir.gates import CNOTGate
@@ -13,7 +14,7 @@ from bqskit.qis.unitary.unitarymatrix import UnitaryMatrix
 
 
 class TestScanPartitioner:
-    def test_run(self) -> None:
+    def test_run(self, compiler: Compiler) -> None:
         """Test run with a linear topology."""
         #     0  1  2  3  4        #########
         # 0 --o-----o--P--P--    --#-o---o-#-----#######--
@@ -33,7 +34,7 @@ class TestScanPartitioner:
         circ.append_gate(CNOTGate(), [1, 2])
         circ.append_gate(CNOTGate(), [2, 3])
         utry = circ.get_unitary()
-        circ.perform(ScanPartitioner(3))
+        circ = compiler.compile(circ, [ScanPartitioner(3)])
 
         assert len(circ) == 3
         assert all(isinstance(op.gate, CircuitGate) for op in circ)
@@ -43,9 +44,14 @@ class TestScanPartitioner:
         for cycle_index in range(circ.num_cycles):
             assert not circ._is_cycle_idle(cycle_index)
 
-    def test_run_r6(self, r6_qudit_circuit: Circuit) -> None:
+    def test_run_r6(
+        self, r6_qudit_circuit: Circuit,
+        compiler: Compiler,
+    ) -> None:
         utry = r6_qudit_circuit.get_unitary()
-        r6_qudit_circuit.perform(ScanPartitioner(3))
+        r6_qudit_circuit = compiler.compile(
+            r6_qudit_circuit, [ScanPartitioner(3)],
+        )
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -61,7 +67,7 @@ class TestScanPartitioner:
         for cycle_index in range(r6_qudit_circuit.num_cycles):
             assert not r6_qudit_circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_3(self) -> None:
+    def test_corner_case_3(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
         circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [0])
         circuit.append_gate(
@@ -102,7 +108,7 @@ class TestScanPartitioner:
             ],
         )
         utry = circuit.get_unitary()
-        circuit.perform(ScanPartitioner(3))
+        circuit = compiler.compile(circuit, [ScanPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -118,7 +124,7 @@ class TestScanPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_4(self) -> None:
+    def test_corner_case_4(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
 
         circuit.append_gate(
@@ -160,7 +166,7 @@ class TestScanPartitioner:
         )
 
         utry = circuit.get_unitary()
-        circuit.perform(ScanPartitioner(3))
+        circuit = compiler.compile(circuit, [ScanPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -176,7 +182,7 @@ class TestScanPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_7(self) -> None:
+    def test_corner_case_7(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
 
         circuit.append_gate(
@@ -239,7 +245,7 @@ class TestScanPartitioner:
         )
 
         utry = circuit.get_unitary()
-        circuit.perform(ScanPartitioner(3))
+        circuit = compiler.compile(circuit, [ScanPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -255,7 +261,7 @@ class TestScanPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_corner_case_8(self) -> None:
+    def test_corner_case_8(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
 
         circuit.append_gate(
@@ -299,7 +305,7 @@ class TestScanPartitioner:
         circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [4])
 
         utry = circuit.get_unitary()
-        circuit.perform(ScanPartitioner(3))
+        circuit = compiler.compile(circuit, [ScanPartitioner(3)])
 
         assert all(
             isinstance(op.gate, CircuitGate)
@@ -315,7 +321,7 @@ class TestScanPartitioner:
         for cycle_index in range(circuit.num_cycles):
             assert not circuit._is_cycle_idle(cycle_index)
 
-    def test_bigger_block(self) -> None:
+    def test_bigger_block(self, compiler: Compiler) -> None:
         circuit = Circuit(6)
 
         circuit.append_gate(ConstantUnitaryGate(UnitaryMatrix.random(1)), [0])
@@ -333,4 +339,4 @@ class TestScanPartitioner:
             ],
         )
         with pytest.raises(RuntimeError):
-            circuit.perform(ScanPartitioner(3))
+            circuit = compiler.compile(circuit, [ScanPartitioner(3)])

--- a/tests/passes/partitioning/test_single.py
+++ b/tests/passes/partitioning/test_single.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
+from bqskit.compiler.compiler import Compiler
 from bqskit.ir import Operation
 from bqskit.ir.circuit import Circuit
 from bqskit.ir.gates import CircuitGate
 from bqskit.passes import GroupSingleQuditGatePass
 
 
-def test_single_qudit_grouper(r6_qudit_circuit: Circuit) -> None:
-    r6_qudit_circuit.perform(GroupSingleQuditGatePass())
+def test_single_qudit_grouper(
+    r6_qudit_circuit: Circuit,
+    compiler: Compiler,
+) -> None:
+    r6_qudit_circuit = compiler.compile(
+        r6_qudit_circuit, [GroupSingleQuditGatePass()],
+    )
 
     # All single-qudit gates should be in a CircuitGate
     for gate in r6_qudit_circuit.gate_set:

--- a/tests/passes/processing/test_substitute.py
+++ b/tests/passes/processing/test_substitute.py
@@ -13,21 +13,7 @@ def is_variable(op: Operation) -> bool:
 
 
 class TestSubstitute:
-    def test_small_qubit(self) -> None:
-        utry = UnitaryMatrix.identity(4)
-        circuit = Circuit(2)
-        circuit.append_gate(VariableUnitaryGate(2), [0, 1])
-        circuit.instantiate(utry)
-        assert circuit.get_unitary().get_distance_from(utry) < 1e-5
-
-        substitute = SubstitutePass(is_variable, VariableUnitaryGate(1))
-        circuit.perform(substitute)
-        dist = circuit.get_unitary().get_distance_from(utry)
-        assert dist <= 1e-5
-        assert circuit.num_operations == 1
-        assert circuit[0, 0].num_qudits == 1
-
-    def test_small_qubit_with_compiler(self, compiler: Compiler) -> None:
+    def test_small_qubit(self, compiler: Compiler) -> None:
         utry = UnitaryMatrix.identity(4)
         circuit = Circuit(2)
         circuit.append_gate(VariableUnitaryGate(2), [0, 1])

--- a/tests/passes/processing/test_substitute.py
+++ b/tests/passes/processing/test_substitute.py
@@ -27,17 +27,16 @@ class TestSubstitute:
         assert circuit.num_operations == 1
         assert circuit[0, 0].num_qudits == 1
 
-    def test_small_qubit_with_compiler(self) -> None:
-        with Compiler() as compiler:
-            utry = UnitaryMatrix.identity(4)
-            circuit = Circuit(2)
-            circuit.append_gate(VariableUnitaryGate(2), [0, 1])
-            circuit.instantiate(utry)
-            assert circuit.get_unitary().get_distance_from(utry) < 1e-5
+    def test_small_qubit_with_compiler(self, compiler: Compiler) -> None:
+        utry = UnitaryMatrix.identity(4)
+        circuit = Circuit(2)
+        circuit.append_gate(VariableUnitaryGate(2), [0, 1])
+        circuit.instantiate(utry)
+        assert circuit.get_unitary().get_distance_from(utry) < 1e-5
 
-            substitute = SubstitutePass(is_variable, VariableUnitaryGate(1))
-            circuit = compiler.compile(circuit, [substitute])
-            dist = circuit.get_unitary().get_distance_from(utry)
-            assert dist <= 1e-5
-            assert circuit.num_operations == 1
-            assert circuit[0, 0].num_qudits == 1
+        substitute = SubstitutePass(is_variable, VariableUnitaryGate(1))
+        circuit = compiler.compile(circuit, [substitute])
+        dist = circuit.get_unitary().get_distance_from(utry)
+        assert dist <= 1e-5
+        assert circuit.num_operations == 1
+        assert circuit[0, 0].num_qudits == 1

--- a/tests/passes/rules/test_cnot2cz.py
+++ b/tests/passes/rules/test_cnot2cz.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from bqskit.compiler.compiler import Compiler
 from bqskit.ir.circuit import Circuit
 from bqskit.ir.gates import CNOTGate
 from bqskit.ir.gates import CZGate
@@ -7,20 +8,20 @@ from bqskit.ir.gates import U3Gate
 from bqskit.passes import CNOTToCZPass
 
 
-def test_cnot2cz_only_cnots() -> None:
+def test_cnot2cz_only_cnots(compiler: Compiler) -> None:
     circuit = Circuit(3)
     for i in range(100):
         circuit.append_gate(CNOTGate(), (0, 1))
         circuit.append_gate(CNOTGate(), (1, 2))
 
     utry = circuit.get_unitary()
-    circuit.perform(CNOTToCZPass())
+    circuit = compiler.compile(circuit, [CNOTToCZPass()])
     assert CNOTGate() not in circuit.gate_set
     assert CZGate() in circuit.gate_set
     assert circuit.get_unitary().get_distance_from(utry) < 5e-8
 
 
-def test_cnot2cz_with_single_qubit() -> None:
+def test_cnot2cz_with_single_qubit(compiler: Compiler) -> None:
     circuit = Circuit(3)
     for i in range(100):
         circuit.append_gate(U3Gate(), 0)
@@ -35,7 +36,7 @@ def test_cnot2cz_with_single_qubit() -> None:
         circuit.append_gate(U3Gate(), 2)
 
     utry = circuit.get_unitary()
-    circuit.perform(CNOTToCZPass())
+    circuit = compiler.compile(circuit, [CNOTToCZPass()])
     assert CNOTGate() not in circuit.gate_set
     assert CZGate() in circuit.gate_set
     assert circuit.get_unitary().get_distance_from(utry) < 5e-8

--- a/tests/passes/synthesis/test_leap.py
+++ b/tests/passes/synthesis/test_leap.py
@@ -10,15 +10,8 @@ from bqskit.qis import UnitaryMatrix
 
 
 class TestLeap:
-    def test_small_qubit(self) -> None:
-        utry = UnitaryMatrix.random(2)
-        circuit = Circuit.from_unitary(utry)
-        leap = LEAPSynthesisPass()
-        circuit.perform(leap)
-        dist = circuit.get_unitary().get_distance_from(utry)
-        assert dist <= 1e-5
 
-    def test_small_qubit_with_compiler(self, compiler: Compiler) -> None:
+    def test_small_qubit(self, compiler: Compiler) -> None:
         utry = UnitaryMatrix.random(2)
         circuit = Circuit.from_unitary(utry)
         leap = LEAPSynthesisPass()

--- a/tests/passes/synthesis/test_leap.py
+++ b/tests/passes/synthesis/test_leap.py
@@ -18,14 +18,13 @@ class TestLeap:
         dist = circuit.get_unitary().get_distance_from(utry)
         assert dist <= 1e-5
 
-    def test_small_qubit_with_compiler(self) -> None:
-        with Compiler() as compiler:
-            utry = UnitaryMatrix.random(2)
-            circuit = Circuit.from_unitary(utry)
-            leap = LEAPSynthesisPass()
-            circuit = compiler.compile(circuit, [leap])
-            dist = circuit.get_unitary().get_distance_from(utry)
-            assert dist <= 1e-5
+    def test_small_qubit_with_compiler(self, compiler: Compiler) -> None:
+        utry = UnitaryMatrix.random(2)
+        circuit = Circuit.from_unitary(utry)
+        leap = LEAPSynthesisPass()
+        circuit = compiler.compile(circuit, [leap])
+        dist = circuit.get_unitary().get_distance_from(utry)
+        assert dist <= 1e-5
 
     def test_small_qutrit(self) -> None:
         utry = UnitaryMatrix.random(2, [3, 3])

--- a/tests/passes/synthesis/test_qfast.py
+++ b/tests/passes/synthesis/test_qfast.py
@@ -18,14 +18,13 @@ class TestQFAST:
         dist = circuit.get_unitary().get_distance_from(utry)
         assert dist <= 1e-5
 
-    def test_small_qubit_with_compiler(self) -> None:
-        with Compiler() as compiler:
-            utry = UnitaryMatrix.random(2)
-            circuit = Circuit.from_unitary(utry)
-            qfast = QFASTDecompositionPass()
-            circuit = compiler.compile(circuit, [qfast])
-            dist = circuit.get_unitary().get_distance_from(utry)
-            assert dist <= 1e-5
+    def test_small_qubit_with_compiler(self, compiler: Compiler) -> None:
+        utry = UnitaryMatrix.random(2)
+        circuit = Circuit.from_unitary(utry)
+        qfast = QFASTDecompositionPass()
+        circuit = compiler.compile(circuit, [qfast])
+        dist = circuit.get_unitary().get_distance_from(utry)
+        assert dist <= 1e-5
 
     def test_3_qubit(self) -> None:
         utry = UnitaryMatrix.random(3)
@@ -35,14 +34,13 @@ class TestQFAST:
         dist = circuit.get_unitary().get_distance_from(utry)
         assert dist <= 1e-5
 
-    def test_3_qubit_with_compiler(self) -> None:
-        with Compiler() as compiler:
-            utry = UnitaryMatrix.random(3)
-            circuit = Circuit.from_unitary(utry)
-            qfast = QFASTDecompositionPass()
-            circuit = compiler.compile(circuit, [qfast])
-            dist = circuit.get_unitary().get_distance_from(utry)
-            assert dist <= 1e-5
+    def test_3_qubit_with_compiler(self, compiler: Compiler) -> None:
+        utry = UnitaryMatrix.random(3)
+        circuit = Circuit.from_unitary(utry)
+        qfast = QFASTDecompositionPass()
+        circuit = compiler.compile(circuit, [qfast])
+        dist = circuit.get_unitary().get_distance_from(utry)
+        assert dist <= 1e-5
 
     def test_3_qubit_with_cnot_block(self) -> None:
         circuit = Circuit(2)

--- a/tests/passes/synthesis/test_qfast.py
+++ b/tests/passes/synthesis/test_qfast.py
@@ -10,15 +10,7 @@ from bqskit.qis import UnitaryMatrix
 
 
 class TestQFAST:
-    def test_small_qubit(self) -> None:
-        utry = UnitaryMatrix.random(2)
-        circuit = Circuit.from_unitary(utry)
-        qfast = QFASTDecompositionPass()
-        circuit.perform(qfast)
-        dist = circuit.get_unitary().get_distance_from(utry)
-        assert dist <= 1e-5
-
-    def test_small_qubit_with_compiler(self, compiler: Compiler) -> None:
+    def test_small_qubit(self, compiler: Compiler) -> None:
         utry = UnitaryMatrix.random(2)
         circuit = Circuit.from_unitary(utry)
         qfast = QFASTDecompositionPass()
@@ -26,15 +18,7 @@ class TestQFAST:
         dist = circuit.get_unitary().get_distance_from(utry)
         assert dist <= 1e-5
 
-    def test_3_qubit(self) -> None:
-        utry = UnitaryMatrix.random(3)
-        circuit = Circuit.from_unitary(utry)
-        qfast = QFASTDecompositionPass()
-        circuit.perform(qfast)
-        dist = circuit.get_unitary().get_distance_from(utry)
-        assert dist <= 1e-5
-
-    def test_3_qubit_with_compiler(self, compiler: Compiler) -> None:
+    def test_3_qubit(self, compiler: Compiler) -> None:
         utry = UnitaryMatrix.random(3)
         circuit = Circuit.from_unitary(utry)
         qfast = QFASTDecompositionPass()

--- a/tests/passes/synthesis/test_qpredict.py
+++ b/tests/passes/synthesis/test_qpredict.py
@@ -7,15 +7,8 @@ from bqskit.qis import UnitaryMatrix
 
 
 class TestQPredict:
-    def test_small_qubit(self) -> None:
-        utry = UnitaryMatrix.random(2)
-        circuit = Circuit.from_unitary(utry)
-        qpredict = QPredictDecompositionPass()
-        circuit.perform(qpredict)
-        dist = circuit.get_unitary().get_distance_from(utry)
-        assert dist <= 1e-3
 
-    def test_small_qubit_with_compiler(self, compiler: Compiler) -> None:
+    def test_small_qubit(self, compiler: Compiler) -> None:
         utry = UnitaryMatrix.random(2)
         circuit = Circuit.from_unitary(utry)
         qpredict = QPredictDecompositionPass()
@@ -23,15 +16,7 @@ class TestQPredict:
         dist = circuit.get_unitary().get_distance_from(utry)
         assert dist <= 1e-3
 
-    def test_3_qubit(self) -> None:
-        utry = UnitaryMatrix.random(3)
-        circuit = Circuit.from_unitary(utry)
-        qpredict = QPredictDecompositionPass()
-        circuit.perform(qpredict)
-        dist = circuit.get_unitary().get_distance_from(utry)
-        assert dist <= 1e-3
-
-    def test_3_qubit_with_compiler(self, compiler: Compiler) -> None:
+    def test_3_qubit(self, compiler: Compiler) -> None:
         utry = UnitaryMatrix.random(3)
         circuit = Circuit.from_unitary(utry)
         qpredict = QPredictDecompositionPass()

--- a/tests/passes/synthesis/test_qpredict.py
+++ b/tests/passes/synthesis/test_qpredict.py
@@ -15,14 +15,13 @@ class TestQPredict:
         dist = circuit.get_unitary().get_distance_from(utry)
         assert dist <= 1e-3
 
-    def test_small_qubit_with_compiler(self) -> None:
-        with Compiler() as compiler:
-            utry = UnitaryMatrix.random(2)
-            circuit = Circuit.from_unitary(utry)
-            qpredict = QPredictDecompositionPass()
-            circuit = compiler.compile(circuit, [qpredict])
-            dist = circuit.get_unitary().get_distance_from(utry)
-            assert dist <= 1e-3
+    def test_small_qubit_with_compiler(self, compiler: Compiler) -> None:
+        utry = UnitaryMatrix.random(2)
+        circuit = Circuit.from_unitary(utry)
+        qpredict = QPredictDecompositionPass()
+        circuit = compiler.compile(circuit, [qpredict])
+        dist = circuit.get_unitary().get_distance_from(utry)
+        assert dist <= 1e-3
 
     def test_3_qubit(self) -> None:
         utry = UnitaryMatrix.random(3)
@@ -32,11 +31,10 @@ class TestQPredict:
         dist = circuit.get_unitary().get_distance_from(utry)
         assert dist <= 1e-3
 
-    def test_3_qubit_with_compiler(self) -> None:
-        with Compiler() as compiler:
-            utry = UnitaryMatrix.random(3)
-            circuit = Circuit.from_unitary(utry)
-            qpredict = QPredictDecompositionPass()
-            circuit = compiler.compile(circuit, [qpredict])
-            dist = circuit.get_unitary().get_distance_from(utry)
-            assert dist <= 1e-3
+    def test_3_qubit_with_compiler(self, compiler: Compiler) -> None:
+        utry = UnitaryMatrix.random(3)
+        circuit = Circuit.from_unitary(utry)
+        qpredict = QPredictDecompositionPass()
+        circuit = compiler.compile(circuit, [qpredict])
+        dist = circuit.get_unitary().get_distance_from(utry)
+        assert dist <= 1e-3

--- a/tests/passes/synthesis/test_qsearch.py
+++ b/tests/passes/synthesis/test_qsearch.py
@@ -21,14 +21,13 @@ class TestQSearch:
         dist = circuit.get_unitary().get_distance_from(utry)
         assert dist <= 1e-5
 
-    def test_small_qubit_with_compiler(self) -> None:
-        with Compiler() as compiler:
-            utry = UnitaryMatrix.random(2)
-            circuit = Circuit.from_unitary(utry)
-            qsearch = QSearchSynthesisPass()
-            circuit = compiler.compile(circuit, [qsearch])
-            dist = circuit.get_unitary().get_distance_from(utry, 1)
-            assert dist <= 1e-5
+    def test_small_qubit_with_compiler(self, compiler: Compiler) -> None:
+        utry = UnitaryMatrix.random(2)
+        circuit = Circuit.from_unitary(utry)
+        qsearch = QSearchSynthesisPass()
+        circuit = compiler.compile(circuit, [qsearch])
+        dist = circuit.get_unitary().get_distance_from(utry, 1)
+        assert dist <= 1e-5
 
     def test_small_qutrit(self) -> None:
         utry = UnitaryMatrix.random(2, [3, 3])

--- a/tests/passes/synthesis/test_qsearch.py
+++ b/tests/passes/synthesis/test_qsearch.py
@@ -13,15 +13,8 @@ from bqskit.qis import UnitaryMatrix
 
 
 class TestQSearch:
-    def test_small_qubit(self) -> None:
-        utry = UnitaryMatrix.random(2)
-        circuit = Circuit.from_unitary(utry)
-        qsearch = QSearchSynthesisPass()
-        circuit.perform(qsearch)
-        dist = circuit.get_unitary().get_distance_from(utry)
-        assert dist <= 1e-5
 
-    def test_small_qubit_with_compiler(self, compiler: Compiler) -> None:
+    def test_small_qubit(self, compiler: Compiler) -> None:
         utry = UnitaryMatrix.random(2)
         circuit = Circuit.from_unitary(utry)
         qsearch = QSearchSynthesisPass()

--- a/tests/passes/util/test_extend.py
+++ b/tests/passes/util/test_extend.py
@@ -1,25 +1,30 @@
 from __future__ import annotations
 
+from bqskit.compiler.compiler import Compiler
 from bqskit.ir.circuit import Circuit
 from bqskit.ir.gates import CircuitGate
 from bqskit.passes import ExtendBlockSizePass
 from bqskit.passes import QuickPartitioner
 
 
-def test_extend_3(r6_qudit_circuit: Circuit) -> None:
+def test_extend_3(r6_qudit_circuit: Circuit, compiler: Compiler) -> None:
     in_utry = r6_qudit_circuit.get_unitary()
-    r6_qudit_circuit.perform(QuickPartitioner(3))
-    r6_qudit_circuit.perform(ExtendBlockSizePass(3))
+    r6_qudit_circuit = compiler.compile(r6_qudit_circuit, [QuickPartitioner(3)])
+    r6_qudit_circuit = compiler.compile(
+        r6_qudit_circuit, [ExtendBlockSizePass(3)],
+    )
     out_utry = r6_qudit_circuit.get_unitary()
     assert all(isinstance(op.gate, CircuitGate) for op in r6_qudit_circuit)
     assert all(op.num_qudits == 3 for op in r6_qudit_circuit)
     assert in_utry == out_utry
 
 
-def test_extend_4(r6_qudit_circuit: Circuit) -> None:
+def test_extend_4(r6_qudit_circuit: Circuit, compiler: Compiler) -> None:
     in_utry = r6_qudit_circuit.get_unitary()
-    r6_qudit_circuit.perform(QuickPartitioner(3))
-    r6_qudit_circuit.perform(ExtendBlockSizePass(4))
+    r6_qudit_circuit = compiler.compile(r6_qudit_circuit, [QuickPartitioner(3)])
+    r6_qudit_circuit = compiler.compile(
+        r6_qudit_circuit, [ExtendBlockSizePass(4)],
+    )
     out_utry = r6_qudit_circuit.get_unitary()
     assert all(isinstance(op.gate, CircuitGate) for op in r6_qudit_circuit)
     assert all(op.num_qudits == 4 for op in r6_qudit_circuit)


### PR DESCRIPTION
Using the compiler fixture instead of perform, so we eimunate the need to create a run time over and over again.