### PR TITLE
Seeded synthesis

### DIFF
--- a/bqskit/ir/circuit.py
+++ b/bqskit/ir/circuit.py
@@ -277,6 +277,11 @@ class Circuit(DifferentiableUnitary, StateVectorMap, Collection[Operation]):
                 active_qudits.add(qudit)
         return list(sorted(active_qudits))
 
+    @property
+    def is_empty(self) -> bool:
+        """If there are any operations in the Circuit."""
+        return self.num_operations > 0
+
     def is_differentiable(self) -> bool:
         """Check if all gates are differentiable."""
         return all(

--- a/bqskit/ir/circuit.py
+++ b/bqskit/ir/circuit.py
@@ -279,8 +279,8 @@ class Circuit(DifferentiableUnitary, StateVectorMap, Collection[Operation]):
 
     @property
     def is_empty(self) -> bool:
-        """If there are any operations in the Circuit."""
-        return self.num_operations > 0
+        """If there are no operations in the Circuit."""
+        return self.num_operations == 0
 
     def is_differentiable(self) -> bool:
         """Check if all gates are differentiable."""

--- a/bqskit/passes/__init__.py
+++ b/bqskit/passes/__init__.py
@@ -147,6 +147,7 @@ are involved the qubit mapping process.
     ExtendBlockSizePass
     LogErrorPass
     FillSingleQuditGatesPass
+    StructureAnalysisPass
 
 .. rubric:: IO Passes
 
@@ -277,6 +278,7 @@ from bqskit.passes.util.log import LogErrorPass
 from bqskit.passes.util.log import LogPass
 from bqskit.passes.util.random import SetRandomSeedPass
 from bqskit.passes.util.record import RecordStatsPass
+from bqskit.passes.util.structure import StructureAnalysisPass
 from bqskit.passes.util.unfold import UnfoldPass
 from bqskit.passes.util.update import UpdateDataPass
 
@@ -373,4 +375,5 @@ __all__ = [
     'ZXGatePredicate',
     'AllConstantSingleQuditGates',
     'GeneralSQDecomposition',
+    'StructureAnalysisPass',
 ]

--- a/bqskit/passes/search/generators/seed.py
+++ b/bqskit/passes/search/generators/seed.py
@@ -159,8 +159,8 @@ class SeedLayerGenerator(LayerGenerator):
 
     def remove_atomic_units(self, circuit: Circuit) -> list[Circuit]:
         """
-        Return circuits after removing upto self.num_removed synthesis
-        atomic units.
+        Return circuits after removing upto self.num_removed synthesis atomic
+        units.
 
         For two qudit synthesis, these atomic units look like:
 
@@ -229,8 +229,8 @@ class SeedLayerGenerator(LayerGenerator):
 
     def circuit_fits_seed(self, circuit: Circuit, seed: Circuit) -> bool:
         return (
-            circuit.num_qudits == seed.num_qudits and
-            all([cr == sr for (cr, sr) in zip(circuit.radixes, seed.radixes)])
+            circuit.num_qudits == seed.num_qudits
+            and all([c == s for (c, s) in zip(circuit.radixes, seed.radixes)])
         )
 
     def find_usable_seeds(self, circuit: Circuit) -> list[Circuit]:
@@ -261,5 +261,5 @@ class SeedLayerGenerator(LayerGenerator):
 
     def init_data_hash(self, data: PassData) -> PassData:
         if 'seed_seen_before' not in data:
-            data['seed_seen_before'] = set([])
+            data['seed_seen_before'] = set()
         return data

--- a/bqskit/passes/search/generators/seed.py
+++ b/bqskit/passes/search/generators/seed.py
@@ -31,7 +31,7 @@ class SeedLayerGenerator(LayerGenerator):
         Construct a SeedLayerGenerator.
 
         Args:
-            seeds (Circuit | Sequence[Circuit] | None): The seed or seeds
+            seed (Circuit | Sequence[Circuit] | None): The seed or seeds
                 to start synthesis from. (Default: None)
 
             forward_generator (LayerGenerator): A generator used to grow
@@ -41,7 +41,7 @@ class SeedLayerGenerator(LayerGenerator):
                 from the circuit in each backwards branch. (Default: 1)
 
         Raises:
-            TypeError: If `seeds` are not of type None, Circuit,
+            TypeError: If `seed` are not of type None, Circuit,
                 or Sequence[Circuit].
 
             TypeError: If `forward_generator` is not a LayerGenerator.

--- a/bqskit/passes/search/generators/seed.py
+++ b/bqskit/passes/search/generators/seed.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import cast
 from typing import Sequence
-from typing import TypeGuard
 
 from bqskit.compiler.passdata import PassData
 from bqskit.ir.circuit import Circuit
@@ -25,7 +24,7 @@ class SeedLayerGenerator(LayerGenerator):
 
     def __init__(
         self,
-        seed: Circuit | Sequence[Circuit] | None = None,
+        seed: Circuit | Sequence[Circuit],
         forward_generator: LayerGenerator = SimpleLayerGenerator(),
         num_removed: int = 1,
     ) -> None:
@@ -33,10 +32,8 @@ class SeedLayerGenerator(LayerGenerator):
         Construct a SeedLayerGenerator.
 
         Args:
-            seed (Circuit | Sequence[Circuit] | None): The seed or seeds
-                to start synthesis from. If `None`, seed circuits can
-                still be passed when calling `gen_successors` through
-                the `PassData` argument. (Default: None)
+            seed (Circuit | Sequence[Circuit]): The seed or seeds
+                to start synthesis from.
 
             forward_generator (LayerGenerator): A generator used to grow
                 the circuit. (Default: SimpleLayerGenerator)
@@ -60,13 +57,30 @@ class SeedLayerGenerator(LayerGenerator):
                 'Expected integer for num_removed, '
                 f'got {type(num_removed)}.',
             )
+
         if num_removed < 0:
             raise ValueError(
                 'Expected non-negative value for num_removed, '
                 f'got {num_removed}.',
             )
 
-        self.seeds = self.check_valid_seed(seed)
+        if isinstance(seed, Circuit):
+            seed = [seed]
+
+        if not is_sequence(seed):
+            raise TypeError(
+                'Expected a Circuit or Sequence of Circuits for seed, '
+                f'got {type(seed)}.',
+            )
+
+        if not all(isinstance(s, Circuit) for s in seed):
+            msg = 'Expected a Circuit or Sequence of Circuits for seed.'
+            for i, s in enumerate(seed):
+                if not isinstance(s, Circuit):
+                    msg += f'\nGot Sequence with {type(s)} at index {i}.'
+            raise TypeError(msg)
+
+        self.seeds = list(cast(Sequence[Circuit], seed))
         self.forward_generator = forward_generator
         self.num_removed = num_removed
 
@@ -78,59 +92,60 @@ class SeedLayerGenerator(LayerGenerator):
         """
         Generate the initial layer, see LayerGenerator for more.
 
-        Note: For seeded layer generation, the initial_layer is the
-            empty Circuit. The `gen_successors` method checks for this
-            before returning `self.seeds` as successors.
-
         Raises:
             TypeError: If target is not a UnitaryMatrix, StateVector, or
                 StateSystem.
+
+        Notes:
+            - For seeded layer generation, the initial_layer is the
+              empty Circuit. The `gen_successors` method checks for this
+              before returning `self.seeds` as successors.
         """
         if not isinstance(target, (UnitaryMatrix, StateVector, StateSystem)):
             raise TypeError(f'Expected unitary or state, got {type(target)}.')
 
         return Circuit(target.num_qudits, target.radixes)
 
-    def gen_successors(
-        self,
-        circuit: Circuit,
-        data: PassData,
-    ) -> list[Circuit]:
+    def gen_successors(self, circuit: Circuit, data: PassData) -> list[Circuit]:
         """
         Generate the successors of a circuit node.
 
-        If `circuit` is the empty Circuit, seeds with dimension matching
-        `circuit` will be used. If seeds are provided in the PassData
-        argument, they are given priority.
-
-        Raises:
-            TypeError: If `circuit` is not a Circuit.
-
-            ValueError: If `circuit` is a single-qudit circuit.
+        If `circuit` is the empty Circuit, seeds with radixes matching
+        `circuit` will be used. If no seeds match, the empty Circuit will
+        be returned as the only successor with a warning message.
         """
         if not isinstance(circuit, Circuit):
             raise TypeError(f'Expected Circuit, got {type(circuit)}.')
 
-        data = self.init_data_hash(data)
+        if 'seed_seen_before' not in data:
+            data['seed_seen_before'] = set()
 
-        # If circuit is empty Circuit, successors are seeds
+        # If circuit is empty Circuit, successors are the seeds
         if circuit.is_empty:
-            # Check if any seeds match circuit, only use those seeds
             circ_hash = self.hash_structure(circuit)
             # Do not return seeds if empty circuit already visited
             if circ_hash in data['seed_seen_before']:
                 return []
-            data['seed_seen_before'] = {self.hash_structure(circuit)}
-            usable_seeds = self.find_usable_seeds(circuit)
-            if len(usable_seeds) > 0:
-                for seed in usable_seeds:
-                    data['seed_seen_before'].add(self.hash_structure(seed))
-                return usable_seeds
+            data['seed_seen_before'] = {circ_hash}
 
-            else:
-                # Root node of this synthesis tree will not start with
-                # single qubit gates
-                self.no_usable_seeds_warning()
+            # Check if any seeds match circuit, only use those seeds
+            usable_seeds = [
+                seed for seed in self.seeds
+                if circuit.radixes == seed.radixes
+            ]
+            for seed in usable_seeds:
+                data['seed_seen_before'].add(self.hash_structure(seed))
+
+            if len(usable_seeds) == 0:
+                _logger.warning(
+                    'No seeds matching the circuit\'s radixes found.'
+                    '\nGenerating successors from empty circuit.'
+                    '\nThis may cause a malformed search tree because the'
+                    'generator never generated a proper initial layer.',
+                )
+                usable_seeds.append(circuit)
+
+            return usable_seeds
 
         # Generate successors
         successors = self.forward_generator.gen_successors(circuit, data)
@@ -139,6 +154,7 @@ class SeedLayerGenerator(LayerGenerator):
         ancestor_circuits = self.remove_atomic_units(circuit)
         successors = ancestor_circuits + successors
 
+        # Filter out successors that have already been visited
         filtered_successors = []
         for s in successors:
             h = self.hash_structure(s)
@@ -159,8 +175,11 @@ class SeedLayerGenerator(LayerGenerator):
 
     def remove_atomic_units(self, circuit: Circuit) -> list[Circuit]:
         """
-        Return circuits after removing upto self.num_removed synthesis atomic
-        units.
+        Return circuits after removing upto `self.num_removed` atomic units.
+
+        Atomic units defined as multi-qudit gates and the single-qudit
+        gates that are directly dependent on them. Except for single-qudit
+        circuits, where the single-qudit gate is the atomic unit.
 
         For two qudit synthesis, these atomic units look like:
 
@@ -171,8 +190,6 @@ class SeedLayerGenerator(LayerGenerator):
         Generally, this will find the last `num_removed` multi-qudit
         gates, and remove them and any single qudit gates that are
         directly dependent on them.
-
-        This function will leave single qudit circutis unchanged.
         """
         num_removed = 0
         ancestor_circuits = []
@@ -180,9 +197,10 @@ class SeedLayerGenerator(LayerGenerator):
         circuit_copy = circuit.copy()
 
         if circuit_copy.num_qudits == 1:
-            init_num_cycles = circuit_copy.depth
-            for _ in range(min((self.num_removed, init_num_cycles))):
-                circuit_copy.pop_cycle(circuit_copy.depth - 1)
+            init_num_cycles = circuit_copy.num_cycles
+            for _ in range(min(self.num_removed, init_num_cycles)):
+                circuit_copy.pop_cycle(-1)
+                ancestor_circuits.append(circuit_copy.copy())
 
         for cycle, op in circuit.operations_with_cycles(reverse=True):
 
@@ -201,71 +219,7 @@ class SeedLayerGenerator(LayerGenerator):
 
             circuit_copy.batch_pop(to_remove)
 
-            ancestor_circuits.append(circuit_copy)
-            circuit_copy = circuit_copy.copy()
+            ancestor_circuits.append(circuit_copy.copy())
             num_removed += 1
 
         return ancestor_circuits
-
-    def is_seed_circuit_seq(self, seed: Any) -> TypeGuard[Sequence[Circuit]]:
-        return is_sequence(seed) and all([self.is_circuit(s) for s in seed])
-
-    def is_circuit(self, seed: Any) -> TypeGuard[Circuit]:
-        return isinstance(seed, Circuit)
-
-    def check_valid_seed(self, seed: Any) -> list[Circuit]:
-        if self.is_circuit(seed):
-            return [seed]
-        elif self.is_seed_circuit_seq(seed):
-            return list(seed)
-        elif seed is None:
-            return []
-        else:
-            msg = 'Provided seed must be a Circuit | Sequence[Circuit] | None.'
-            if is_sequence(seed):
-                for i, s in enumerate(seed):
-                    if not isinstance(s, Circuit):
-                        msg += (
-                            f' Got Sequence with type [{type(s)}] '
-                            f'at index {i}.'
-                        )
-            else:
-                msg += f' Got type {type(seed)} instead.'
-            raise ValueError(msg)
-
-    def circuit_fits_seed(self, circuit: Circuit, seed: Circuit) -> bool:
-        return (
-            circuit.num_qudits == seed.num_qudits
-            and all([c == s for (c, s) in zip(circuit.radixes, seed.radixes)])
-        )
-
-    def find_usable_seeds(self, circuit: Circuit) -> list[Circuit]:
-        usable_seeds = []
-        for seed in self.seeds:
-            if not self.circuit_fits_seed(circuit, seed):
-                continue
-            usable_seeds.append(seed)
-        return usable_seeds
-
-    def no_usable_seeds_warning(self) -> None:
-        """
-        Log warning if no usable seeds. Circuit may be malformed.
-
-        Give additional warning if no seeds were provided at initialization
-        and the `PassData` object contains no `seed_circuits` key.
-        """
-        msg = (
-            'Generating successors from empty circuit. '
-            'This circuit may be malformed.'
-        )
-        if len(self.seeds) == 0:
-            msg += (
-                'No seeds provided at initialization (seed = None), '
-                'but no usable seeds provided in `PassData`.'
-            )
-        _logger.warning(msg)
-
-    def init_data_hash(self, data: PassData) -> PassData:
-        if 'seed_seen_before' not in data:
-            data['seed_seen_before'] = set()
-        return data

--- a/bqskit/passes/search/generators/seed.py
+++ b/bqskit/passes/search/generators/seed.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Sequence
 
 from bqskit.compiler.passdata import PassData
 from bqskit.ir.circuit import Circuit
@@ -19,23 +20,50 @@ class SeedLayerGenerator(LayerGenerator):
 
     def __init__(
         self,
-        seed: Circuit,
+        seeds: Circuit | Sequence[Circuit],
         forward_generator: LayerGenerator = SimpleLayerGenerator(),
-        num_removed: int = 1,
+        back_step_size: int = 1,
     ) -> None:
         """
         Construct a SeedLayerGenerator.
 
         Args:
-            seed (Circuit): The seed to start from.
+            seeds (Circuit | Sequence[Circuit]): The seed or seeds to start
+                synthesis from.
 
-            forward_generator (Gate): A generator used to grow the circuit.
+            forward_generator (LayerGenerator): A generator used to grow
+                the circuit.
 
-            num_removed (int): The number of gates removed from the circuit
-                in each backwards branch.
+            back_step_size (int): The number of atomic gate units removed from
+                the circuit in each backwards branch.
+
+        Raises:
+            TypeError: If `seeds` are not a Sequence of Circuits or a
+                single Circuit.
+
+            ValueError: If Circuits in `seeds` do not all have the same
+                dimension.
+
+            TypeError: If `forward_generator` is not a LayerGenerator.
+
+            TypeError: If `back_step_size` is not an integer.
+
+            ValueError: If 'back_step_size' is negative.
         """
-        if not isinstance(seed, Circuit):
-            raise TypeError(f'Expected Circuit for seed, got {type(seed)}')
+        if not isinstance(seeds, Circuit) and not isinstance(seeds, Sequence):
+            raise TypeError(
+                f'Expected Circuit or Sequence of Circuits for '
+                f'seed, got {type(seeds)} instead.',
+            )
+
+        if isinstance(seeds, Sequence):
+            if not all([isinstance(c, Circuit) for c in seeds]):
+                raise TypeError('Expected seed to be Sequence of Circuits.')
+            self.seed_dim = seeds[0].dim
+            if not all([s.dim == self.seed_dim for s in seeds]):
+                raise ValueError('Each seed must be the same dimension.')
+        else:
+            self.seed_dim = seeds.dim
 
         if not isinstance(forward_generator, LayerGenerator):
             raise TypeError(
@@ -43,20 +71,26 @@ class SeedLayerGenerator(LayerGenerator):
                 f', got {type(forward_generator)}.',
             )
 
-        if not is_integer(num_removed):
+        if not is_integer(back_step_size):
             raise TypeError(
-                f'Expected integer for num_removed, got {type(num_removed)}.',
+                'Expected integer for back_step_size, '
+                f'got {type(back_step_size)}.',
+            )
+        if back_step_size < 0:
+            raise ValueError(
+                'Expected non-negative value for back_step_size, '
+                f'got {back_step_size}.',
             )
 
-        self.seed = seed
+        self.seeds = [seeds] if not isinstance(seeds, Sequence) else list(seeds)
         self.forward_generator = forward_generator
-        self.num_removed = num_removed
+        self.back_step_size = back_step_size
 
     def gen_initial_layer(
         self,
         target: UnitaryMatrix | StateVector | StateSystem,
         data: PassData,
-    ) -> Circuit:
+    ) -> list[Circuit]:
         """
         Generate the initial layer, see LayerGenerator for more.
 
@@ -65,46 +99,40 @@ class SeedLayerGenerator(LayerGenerator):
                 `self.seed`.
         """
 
-        if not isinstance(target, (UnitaryMatrix, StateVector, StateSystem)):
-            raise TypeError(
-                'Expected unitary or state, got %s.' % type(target),
-            )
+        if not isinstance(target, (UnitaryMatrix, StateVector)):
+            raise TypeError(f'Expected unitary or state, got {type(target)}.')
 
-        if target.dim != self.seed.dim:
+        if target.dim != self.seed_dim:
             raise ValueError('Seed dimension mismatch with target.')
 
-        data['seed_seen_before'] = {self.hash_structure(self.seed)}
+        for seed in self.seeds:
+            data['seed_seen_before'] = {self.hash_structure(seed)}
 
-        return self.seed
+        return self.seeds
 
-    def gen_successors(self, circuit: Circuit, data: PassData) -> list[Circuit]:
+    def gen_successors(
+        self,
+        circuit: Circuit,
+        data: PassData,
+    ) -> list[Circuit]:
         """
         Generate the successors of a circuit node.
 
         Raises:
             ValueError: If circuit is a single-qudit circuit.
         """
-
         if not isinstance(circuit, Circuit):
-            raise TypeError('Expected circuit, got %s.' % type(circuit))
+            raise TypeError(f'Expected Circuit , got {type(circuit)}.')
 
-        if circuit.num_qudits < 2:
-            raise ValueError('Cannot expand a single-qudit circuit.')
-
-        if circuit.dim != self.seed.dim:
-            raise ValueError('Seed dimension mismatch with circuit.')
+        if circuit.dim != self.seed_dim:
+            raise ValueError('Seed and circuit dimensions do not match.')
 
         # Generate successors
         successors = self.forward_generator.gen_successors(circuit, data)
 
-        removed_count = 0
-        for cycle, op in circuit.operations_with_cycles(reverse=True):
-            removed_count += 1
-            if removed_count > self.num_removed:
-                break
-            copied_circuit = circuit.copy()
-            copied_circuit.pop((cycle, op.location[0]))
-            successors.insert(0, copied_circuit)
+        # Search reverse direction
+        ancestor_circuits = self.remove_atomic_units(circuit)
+        successors = ancestor_circuits + successors
 
         filtered_successors = []
         for s in successors:
@@ -123,3 +151,37 @@ class SeedLayerGenerator(LayerGenerator):
             if len(hashes) > 100:
                 hashes = [sum(hashes)]
         return sum(hashes)
+
+    def remove_atomic_units(self, circuit: Circuit) -> list[Circuit]:
+        """
+        Search for the last `back_step_size` number of atmoic units:
+
+            -- two_qudit_gate -- single_qudit_gate_1 --
+                    |
+            -- two_qudit_gate -- single_qudit_gate_2 --
+
+        and remove them.
+        """
+        num_removed = 0
+        ancestor_circuits = []
+
+        circuit_copy = circuit.copy()
+        for cycle, op in circuit.operations_with_cycles(reverse=True):
+
+            if num_removed >= self.back_step_size:
+                break
+            if op.num_qudits == 1:
+                continue
+
+            for place in op.location:
+                point = (cycle + 1, place)
+                if not circuit_copy.is_point_idle(point):
+                    circuit_copy.pop(point)
+
+            circuit_copy.pop((cycle, op.location[0]))
+
+            ancestor_circuits.append(circuit_copy)
+            circuit_copy = circuit_copy.copy()
+            num_removed += 1
+
+        return ancestor_circuits

--- a/bqskit/passes/search/generators/seed.py
+++ b/bqskit/passes/search/generators/seed.py
@@ -178,6 +178,12 @@ class SeedLayerGenerator(LayerGenerator):
         ancestor_circuits = []
 
         circuit_copy = circuit.copy()
+
+        if circuit_copy.num_qudits == 1:
+            init_num_cycles = circuit_copy.depth
+            for _ in range(min((self.num_removed, init_num_cycles))):
+                circuit_copy.pop_cycle(circuit_copy.depth - 1)
+
         for cycle, op in circuit.operations_with_cycles(reverse=True):
 
             if num_removed >= self.num_removed:

--- a/bqskit/passes/synthesis/leap.py
+++ b/bqskit/passes/synthesis/leap.py
@@ -14,7 +14,6 @@ from bqskit.ir.opt.cost.generator import CostFunctionGenerator
 from bqskit.passes.search.frontier import Frontier
 from bqskit.passes.search.generator import LayerGenerator
 from bqskit.passes.search.generators.seed import SeedLayerGenerator
-from bqskit.passes.search.generators.simple import SimpleLayerGenerator
 from bqskit.passes.search.heuristic import HeuristicFunction
 from bqskit.passes.search.heuristics import AStarHeuristic
 from bqskit.passes.synthesis.synthesis import SynthesisPass

--- a/bqskit/passes/synthesis/leap.py
+++ b/bqskit/passes/synthesis/leap.py
@@ -366,9 +366,9 @@ class LEAPSynthesisPass(SynthesisPass):
             if isinstance(_gen, SimpleLayerGenerator):
                 _logger.warning(
                     'No provided `self.layer_gen` and no `gate_set` specified '
-                    'in PassData. Defaulting to `SimpleLayerGenerator`.'
+                    'in PassData. Defaulting to `SimpleLayerGenerator`.',
                 )
-            _gen: LayerGenerator = SeedLayerGenerator(
+            _gen = SeedLayerGenerator(
                 seed=data['seed_circuits'],
                 forward_generator=_gen,
             )

--- a/bqskit/passes/synthesis/leap.py
+++ b/bqskit/passes/synthesis/leap.py
@@ -356,18 +356,11 @@ class LEAPSynthesisPass(SynthesisPass):
     def _set_layer_gen(self, data: PassData) -> LayerGenerator:
         if self.layer_gen is not None:
             _gen = self.layer_gen
-        elif 'gate_set' in data:
-            _gen = data.gate_set.build_mq_layer_generator()
         else:
-            _gen = SimpleLayerGenerator()
+            _gen = data.gate_set.build_mq_layer_generator()
 
         # Priority given to seeded synthesis
         if 'seed_circuits' in data:
-            if isinstance(_gen, SimpleLayerGenerator):
-                _logger.warning(
-                    'No provided `self.layer_gen` and no `gate_set` specified '
-                    'in PassData. Defaulting to `SimpleLayerGenerator`.',
-                )
             _gen = SeedLayerGenerator(
                 seed=data['seed_circuits'],
                 forward_generator=_gen,

--- a/bqskit/passes/synthesis/qsearch.py
+++ b/bqskit/passes/synthesis/qsearch.py
@@ -238,21 +238,20 @@ class QSearchSynthesisPass(SynthesisPass):
         return best_circ
 
     def _set_layer_gen(self, data: PassData) -> LayerGenerator:
-
         if self.layer_gen is not None:
             _gen = self.layer_gen
-        elif 'gate_set' in data.keys():
+        elif 'gate_set' in data:
             _gen = data.gate_set.build_mq_layer_generator()
         else:
-            _logger.warning(
-                'No provided `self.layer_gen` and no `gate_set` specified '
-                'in PassData. Defaulting to `SimpleLayerGenerator`.'
-            )
             _gen = SimpleLayerGenerator()
 
         # Priority given to seeded synthesis
         if 'seed_circuits' in data:
-            # Assumes that seed_circuits are compatible with machine model
+            if isinstance(_gen, SimpleLayerGenerator):
+                _logger.warning(
+                    'No provided `self.layer_gen` and no `gate_set` specified '
+                    'in PassData. Defaulting to `SimpleLayerGenerator`.'
+                )
             _gen: LayerGenerator = SeedLayerGenerator(
                 seed=data['seed_circuits'],
                 forward_generator=_gen,

--- a/bqskit/passes/synthesis/qsearch.py
+++ b/bqskit/passes/synthesis/qsearch.py
@@ -89,7 +89,7 @@ class QSearchSynthesisPass(SynthesisPass):
         """
         if not isinstance(heuristic_function, HeuristicFunction):
             raise TypeError(
-                f'Expected HeursiticFunction, got {type(heuristic_function)}.'
+                f'Expected HeursiticFunction, got {type(heuristic_function)}.',
             )
 
         if layer_generator is not None:
@@ -101,29 +101,29 @@ class QSearchSynthesisPass(SynthesisPass):
         if not is_real_number(success_threshold):
             raise TypeError(
                 'Expected real number for success_threshold'
-                f', got {type(success_threshold)}'
+                f', got {type(success_threshold)}',
             )
 
         if not isinstance(cost, CostFunctionGenerator):
             raise TypeError(
                 'Expected cost to be a CostFunctionGenerator'
-                f', got {type(cost)}'
+                f', got {type(cost)}',
             )
 
         if max_layer is not None and not is_integer(max_layer):
             raise TypeError(
-                f'Expected max_layer to be an integer, got {type(max_layer)}.'
+                f'Expected max_layer to be an integer, got {type(max_layer)}.',
             )
 
         if max_layer is not None and max_layer <= 0:
             raise ValueError(
-                f'Expected max_layer to be positive, got {int(max_layer)}.'
+                f'Expected max_layer to be positive, got {int(max_layer)}.',
             )
 
         if not isinstance(instantiate_options, dict):
             raise TypeError(
                 'Expected dictionary for instantiate_options'
-                f', got {type(instantiate_options)}'
+                f', got {type(instantiate_options)}',
             )
 
         self.heuristic_function = heuristic_function
@@ -250,9 +250,9 @@ class QSearchSynthesisPass(SynthesisPass):
             if isinstance(_gen, SimpleLayerGenerator):
                 _logger.warning(
                     'No provided `self.layer_gen` and no `gate_set` specified '
-                    'in PassData. Defaulting to `SimpleLayerGenerator`.'
+                    'in PassData. Defaulting to `SimpleLayerGenerator`.',
                 )
-            _gen: LayerGenerator = SeedLayerGenerator(
+            _gen = SeedLayerGenerator(
                 seed=data['seed_circuits'],
                 forward_generator=_gen,
             )

--- a/bqskit/passes/synthesis/qsearch.py
+++ b/bqskit/passes/synthesis/qsearch.py
@@ -240,18 +240,11 @@ class QSearchSynthesisPass(SynthesisPass):
     def _set_layer_gen(self, data: PassData) -> LayerGenerator:
         if self.layer_gen is not None:
             _gen = self.layer_gen
-        elif 'gate_set' in data:
-            _gen = data.gate_set.build_mq_layer_generator()
         else:
-            _gen = SimpleLayerGenerator()
+            _gen = data.gate_set.build_mq_layer_generator()
 
         # Priority given to seeded synthesis
         if 'seed_circuits' in data:
-            if isinstance(_gen, SimpleLayerGenerator):
-                _logger.warning(
-                    'No provided `self.layer_gen` and no `gate_set` specified '
-                    'in PassData. Defaulting to `SimpleLayerGenerator`.',
-                )
             _gen = SeedLayerGenerator(
                 seed=data['seed_circuits'],
                 forward_generator=_gen,

--- a/bqskit/passes/synthesis/qsearch.py
+++ b/bqskit/passes/synthesis/qsearch.py
@@ -150,9 +150,8 @@ class QSearchSynthesisPass(SynthesisPass):
         if 'seed' not in instantiate_options:
             instantiate_options['seed'] = data.seed
 
-        # Set layer generator depending on if seed_circuits or another
-        # LayerGenerator have been provided
-        layer_gen = self._set_layer_gen(data)
+        # Get layer generator for search
+        layer_gen = self._get_layer_gen(data)
 
         # Begin the search with an initial layer
         frontier = Frontier(utry, self.heuristic_function)
@@ -236,16 +235,22 @@ class QSearchSynthesisPass(SynthesisPass):
 
         return best_circ
 
-    def _set_layer_gen(self, data: PassData) -> LayerGenerator:
-        if self.layer_gen is not None:
-            _gen = self.layer_gen
-        else:
-            _gen = data.gate_set.build_mq_layer_generator()
+    def _get_layer_gen(self, data: PassData) -> LayerGenerator:
+        """
+        Set the layer generator.
+
+        If a layer generator has been passed into the constructor, then that
+        layer generator will be used. Otherwise, a default layer generator will
+        be selected by the gateset.
+
+        If seeds are passed into the data dict, then a SeedLayerGenerator will
+        wrap the previously selected layer generator.
+        """
+        # TODO: Deduplicate this code with leap synthesis
+        layer_gen = self.layer_gen or data.gate_set.build_mq_layer_generator()
 
         # Priority given to seeded synthesis
         if 'seed_circuits' in data:
-            _gen = SeedLayerGenerator(
-                seed=data['seed_circuits'],
-                forward_generator=_gen,
-            )
-        return _gen
+            return SeedLayerGenerator(data['seed_circuits'], layer_gen)
+
+        return layer_gen

--- a/bqskit/passes/synthesis/qsearch.py
+++ b/bqskit/passes/synthesis/qsearch.py
@@ -11,7 +11,6 @@ from bqskit.ir.opt.cost.generator import CostFunctionGenerator
 from bqskit.passes.search.frontier import Frontier
 from bqskit.passes.search.generator import LayerGenerator
 from bqskit.passes.search.generators.seed import SeedLayerGenerator
-from bqskit.passes.search.generators.simple import SimpleLayerGenerator
 from bqskit.passes.search.heuristic import HeuristicFunction
 from bqskit.passes.search.heuristics import AStarHeuristic
 from bqskit.passes.synthesis.synthesis import SynthesisPass

--- a/bqskit/passes/util/__init__.py
+++ b/bqskit/passes/util/__init__.py
@@ -11,6 +11,7 @@ from bqskit.passes.util.log import LogErrorPass
 from bqskit.passes.util.log import LogPass
 from bqskit.passes.util.random import SetRandomSeedPass
 from bqskit.passes.util.record import RecordStatsPass
+from bqskit.passes.util.structure import StructureAnalysisPass
 from bqskit.passes.util.unfold import UnfoldPass
 from bqskit.passes.util.update import UpdateDataPass
 
@@ -27,4 +28,5 @@ __all__ = [
     'LogErrorPass',
     'FillSingleQuditGatesPass',
     'ToVariablePass',
+    'StructureAnalysisPass',
 ]

--- a/bqskit/passes/util/structure.py
+++ b/bqskit/passes/util/structure.py
@@ -5,29 +5,37 @@ from bqskit.compiler.basepass import BasePass
 from bqskit.compiler.passdata import PassData
 from bqskit.ir.circuit import Circuit
 from bqskit.ir.circuit import CircuitGate
+from bqskit.ir.structure import CircuitStructure
 
 
 class StructureAnalysisPass(BasePass):
-    """A pass that catalogs circuit structures used in a partitioned circ-
-    uit."""
+    """
+    A pass that catalogs circuit structures used in a partitioned circuit.
+
+    Note: For each partitioned CircuitGate in the Circuit, the recursive
+    `unfold_all` method is called to ensure that structure is defined at
+    the gate level. For structures to be considered the same, they must
+    consist of the same gates, in the same locations.
+    """
 
     def __init__(self) -> None:
-        """Construct a StructureAnalysisPass."""
+        """Construct a StructurePass."""
 
     async def run(self, circuit: Circuit, data: PassData) -> None:
         """Perform the pass's operation, see :class:`BasePass` for more."""
+
         if 'structures' not in data:
             data['structures'] = []
 
-        structures_seen = []
+        structures_seen: list[CircuitStructure] = []
 
         for block in circuit:
             if not isinstance(block.gate, CircuitGate):
                 continue
             subcirc = Circuit.from_operation(block)
+            # Structure depends on the gate level, call unfold_all
             subcirc.unfold_all()
-            subcirc.set_params([0] * subcirc.num_params)
-
-            structures_seen.append(subcirc)
+            structure = CircuitStructure(subcirc)
+            structures_seen.append(structure)
 
         data['structures'].extend(structures_seen)

--- a/bqskit/passes/util/structure.py
+++ b/bqskit/passes/util/structure.py
@@ -1,0 +1,33 @@
+"""This module implements the StructureAnalysisPass."""
+from __future__ import annotations
+
+from bqskit.compiler.basepass import BasePass
+from bqskit.compiler.passdata import PassData
+from bqskit.ir.circuit import Circuit
+from bqskit.ir.circuit import CircuitGate
+
+
+class StructureAnalysisPass(BasePass):
+    """A pass that catalogs circuit structures used in a partitioned circ-
+    uit."""
+
+    def __init__(self) -> None:
+        """Construct a StructureAnalysisPass."""
+
+    async def run(self, circuit: Circuit, data: PassData) -> None:
+        """Perform the pass's operation, see :class:`BasePass` for more."""
+        if 'structures' not in data:
+            data['structures'] = []
+
+        structures_seen = []
+
+        for block in circuit:
+            if not isinstance(block.gate, CircuitGate):
+                continue
+            subcirc = Circuit.from_operation(block)
+            subcirc.unfold_all()
+            subcirc.set_params([0] * subcirc.num_params)
+
+            structures_seen.append(subcirc)
+
+        data['structures'].extend(structures_seen)

--- a/bqskit/passes/util/structure.py
+++ b/bqskit/passes/util/structure.py
@@ -40,7 +40,7 @@ class StructureAnalysisPass(BasePass):
 
         for block in circuit:
             if isinstance(block.gate, CircuitGate):
-                subcirc = block.gate._circuit  # type: ignore
+                subcirc = block.gate._circuit
                 # Structure depends on the gate level, call unfold_all
                 subcirc.unfold_all()
                 structure = CircuitStructure(subcirc)

--- a/tests/passes/search/generators/test_seed.py
+++ b/tests/passes/search/generators/test_seed.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from hypothesis import given
 
+from bqskit.compiler.passdata import PassData
 from bqskit.ir.circuit import Circuit
+from bqskit.ir.gates import CNOTGate
 from bqskit.ir.gates import HGate
+from bqskit.ir.gates import U3Gate
 from bqskit.passes.search.generators import SeedLayerGenerator
 from bqskit.utils.test.strategies import circuits
 
@@ -14,3 +17,115 @@ def test_seed_hash(circuit: Circuit) -> None:
     circuit.append_gate(HGate(), 0)
     hash2 = SeedLayerGenerator.hash_structure(circuit)
     assert hash1 != hash2
+
+
+def test_constructor() -> None:
+    seed_1 = Circuit(2)
+    seed_2 = Circuit(2)
+    seed_1.append_gate(CNOTGate(), (0, 1))
+    seed_2.append_gate(CNOTGate(), (0, 1))
+    seed_2.append_gate(CNOTGate(), (1, 0))
+    no_seed = SeedLayerGenerator()
+    one_seed = SeedLayerGenerator(seed_1)
+    two_seed = SeedLayerGenerator([seed_1, seed_2])
+
+    assert len(no_seed.seeds) == 0
+    assert one_seed.seeds[0] == seed_1
+    assert two_seed.seeds[0] == seed_1
+    assert two_seed.seeds[1] == seed_2
+
+
+def test_gen_initial_layer() -> None:
+    layer_gen = SeedLayerGenerator()
+    for num_q in range(2, 5):
+        empty_circuit = Circuit(num_q)
+        data = PassData(empty_circuit)
+        init_circ = layer_gen.gen_initial_layer(
+            empty_circuit.get_unitary(), data,
+        )
+        assert init_circ.num_operations == 0
+        assert init_circ.num_qudits == num_q
+
+
+def test_remove_atomic_units() -> None:
+    num_q = 4
+    circ = Circuit(num_q)
+    for i in range(num_q):
+        circ.append_gate(U3Gate(), [i])
+    for edge in [(0, 1), (2, 3)]:
+        circ.append_gate(CNOTGate(), edge)
+    for i in range(num_q):
+        circ.append_gate(U3Gate(), [i])
+
+    layer_gen = SeedLayerGenerator(num_removed=2)
+
+    one_left_circ, zero_left_circ = layer_gen.remove_atomic_units(circ)
+
+    assert one_left_circ.num_operations == 7
+    assert zero_left_circ.num_operations == 4
+    assert isinstance(one_left_circ.get_operation((1, 0)).gate, CNOTGate)
+    assert isinstance(one_left_circ.get_operation((2, 0)).gate, U3Gate)
+    assert isinstance(one_left_circ.get_operation((2, 1)).gate, U3Gate)
+    assert zero_left_circ.depth == 1
+
+
+def test_gen_successors() -> None:
+    # Set two seeds, assert that they are returned upon the first call to
+    # gen_successors.
+    seed_1 = Circuit(2)
+    seed_2 = Circuit(2)
+    seed_1.append_gate(CNOTGate(), (0, 1))
+    seed_2.append_gate(CNOTGate(), (0, 1))
+    seed_2.append_gate(CNOTGate(), (1, 0))
+
+    seeds = [seed_1, seed_2]
+    layer_gen = SeedLayerGenerator(seed=seeds)
+
+    target = seed_2.get_unitary()
+    data = PassData(seed_2)
+
+    init_layer = layer_gen.gen_initial_layer(target, data)
+
+    assert init_layer.num_operations == 0
+
+    successors = layer_gen.gen_successors(init_layer, data)
+
+    assert successors[0] == seed_1
+    assert successors[1] == seed_2
+
+    # Check that gen_successors works for non initial circuits
+    successors = layer_gen.gen_successors(seed_2, data)
+    # seed_1 should not be returned because it has already been seed
+    assert len(successors) == 1
+
+    assert successors[0].num_operations == 5
+    assert isinstance(successors[0].get_operation((0, 0)).gate, CNOTGate)
+    assert isinstance(successors[0].get_operation((1, 0)).gate, CNOTGate)
+    assert isinstance(successors[0].get_operation((2, 0)).gate, CNOTGate)
+    assert isinstance(successors[0].get_operation((3, 0)).gate, U3Gate)
+    assert isinstance(successors[0].get_operation((3, 1)).gate, U3Gate)
+
+
+def test_gen_successors_mismatch() -> None:
+    # Have a 2 qubit and 3 qubit seed
+    # Pass in a 3 qubit target and ensure only the 3 qubit seed is used
+    seed_1 = Circuit(2)
+    seed_2 = Circuit(3)
+    seed_1.append_gate(CNOTGate(), (0, 1))
+    seed_2.append_gate(CNOTGate(), (0, 1))
+    seed_2.append_gate(CNOTGate(), (1, 2))
+
+    seeds = [seed_1, seed_2]
+    layer_gen = SeedLayerGenerator(seed=seeds)
+
+    target = seed_2.get_unitary()
+    data = PassData(seed_2)
+
+    init_layer = layer_gen.gen_initial_layer(target, data)
+
+    assert init_layer.num_operations == 0
+
+    successors = layer_gen.gen_successors(init_layer, data)
+
+    assert len(successors) == 1
+    assert successors[0] == seed_2

--- a/tests/passes/synthesis/test_qsearch.py
+++ b/tests/passes/synthesis/test_qsearch.py
@@ -9,6 +9,7 @@ from bqskit.passes import QSearchSynthesisPass
 from bqskit.passes.search.generators.seed import SeedLayerGenerator
 from bqskit.passes.search.generators.simple import SimpleLayerGenerator
 from bqskit.qis import UnitaryMatrix
+from bqskit.passes.util.update import UpdateDataPass
 
 
 class TestQSearch:
@@ -41,13 +42,13 @@ class TestQSearch:
         dist = circuit.get_unitary().get_distance_from(utry, 1)
         assert dist <= 1e-5
 
-    def test_seed_in_data(self) -> None:
+    def test_seed_in_data(self, compiler: Compiler) -> None:
         seed = Circuit(2)
         seed.append_gate(CNOTGate(), (0, 1))
         qsearch = QSearchSynthesisPass()
         utry = UnitaryMatrix.random(2)
         circuit = Circuit.from_unitary(utry)
-        data = {'seed_circuits': [seed]}
-        circuit.perform(qsearch, data)
+        update = UpdateDataPass('seed_circuits', [seed])
+        circuit = compiler.compile(circuit, [qsearch, update])
         dist = circuit.get_unitary().get_distance_from(utry, 1)
         assert dist <= 1e-5

--- a/tests/passes/synthesis/test_qsearch.py
+++ b/tests/passes/synthesis/test_qsearch.py
@@ -8,8 +8,8 @@ from bqskit.ir.gates.parameterized.u8 import U8Gate
 from bqskit.passes import QSearchSynthesisPass
 from bqskit.passes.search.generators.seed import SeedLayerGenerator
 from bqskit.passes.search.generators.simple import SimpleLayerGenerator
-from bqskit.qis import UnitaryMatrix
 from bqskit.passes.util.update import UpdateDataPass
+from bqskit.qis import UnitaryMatrix
 
 
 class TestQSearch:

--- a/tests/passes/synthesis/test_qsearch.py
+++ b/tests/passes/synthesis/test_qsearch.py
@@ -21,23 +21,23 @@ class TestQSearch:
         dist = circuit.get_unitary().get_distance_from(utry, 1)
         assert dist <= 1e-5
 
-    def test_small_qutrit(self) -> None:
+    def test_small_qutrit(self, compiler: Compiler) -> None:
         utry = UnitaryMatrix.random(2, [3, 3])
         circuit = Circuit.from_unitary(utry)
         layer_gen = SimpleLayerGenerator(CPIGate(), U8Gate())
         leap = QSearchSynthesisPass(layer_generator=layer_gen)
-        circuit.perform(leap)
+        circuit = compiler.compile(circuit, [leap])
         dist = circuit.get_unitary().get_distance_from(utry, 1)
         assert dist <= leap.success_threshold
 
-    def test_seed(self) -> None:
+    def test_seed(self, compiler: Compiler) -> None:
         seed = Circuit(2)
         seed.append_gate(CNOTGate(), (0, 1))
         layer_gen = SeedLayerGenerator(seed)
         qsearch = QSearchSynthesisPass(layer_generator=layer_gen)
         utry = UnitaryMatrix.random(2)
         circuit = Circuit.from_unitary(utry)
-        circuit.perform(qsearch)
+        circuit = compiler.compile(circuit, [qsearch])
         dist = circuit.get_unitary().get_distance_from(utry, 1)
         assert dist <= 1e-5
 

--- a/tests/passes/synthesis/test_qsearch.py
+++ b/tests/passes/synthesis/test_qsearch.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 from bqskit.compiler import Compiler
 from bqskit.ir.circuit import Circuit
+from bqskit.ir.gates import CNOTGate
 from bqskit.ir.gates.constant.cpi import CPIGate
 from bqskit.ir.gates.parameterized.u8 import U8Gate
 from bqskit.passes import QSearchSynthesisPass
+from bqskit.passes.search.generators.seed import SeedLayerGenerator
 from bqskit.passes.search.generators.simple import SimpleLayerGenerator
 from bqskit.qis import UnitaryMatrix
-# from bqskit.ir.gates import CPIGate
-# from bqskit.ir.gates import U8Gate
-# from bqskit.passes import SimpleLayerGenerator
 
 
 class TestQSearch:
@@ -30,3 +29,25 @@ class TestQSearch:
         circuit.perform(leap)
         dist = circuit.get_unitary().get_distance_from(utry, 1)
         assert dist <= leap.success_threshold
+
+    def test_seed(self) -> None:
+        seed = Circuit(2)
+        seed.append_gate(CNOTGate(), (0, 1))
+        layer_gen = SeedLayerGenerator(seed)
+        qsearch = QSearchSynthesisPass(layer_generator=layer_gen)
+        utry = UnitaryMatrix.random(2)
+        circuit = Circuit.from_unitary(utry)
+        circuit.perform(qsearch)
+        dist = circuit.get_unitary().get_distance_from(utry, 1)
+        assert dist <= 1e-5
+
+    def test_seed_in_data(self) -> None:
+        seed = Circuit(2)
+        seed.append_gate(CNOTGate(), (0, 1))
+        qsearch = QSearchSynthesisPass()
+        utry = UnitaryMatrix.random(2)
+        circuit = Circuit.from_unitary(utry)
+        data = {'seed_circuits': [seed]}
+        circuit.perform(qsearch, data)
+        dist = circuit.get_unitary().get_distance_from(utry, 1)
+        assert dist <= 1e-5

--- a/tests/passes/util/test_structure.py
+++ b/tests/passes/util/test_structure.py
@@ -2,23 +2,21 @@ from __future__ import annotations
 
 from bqskit.compiler.compiler import Compiler
 from bqskit.ir.circuit import Circuit
-from bqskit.ir.gates import CircuitGate
 from bqskit.ir.gates.constant.cx import CNOTGate
-from bqskit.passes import ExtendBlockSizePass
 from bqskit.passes import QuickPartitioner
-from bqskit.passes.util.structure import StructurePass
+from bqskit.passes.util.structure import StructureAnalysisPass
 
 
 def test_list_structures(compiler: Compiler) -> None:
 
     partitioner = QuickPartitioner(2)
-    analyzer = StructurePass()
+    analyzer = StructureAnalysisPass()
     circuit = Circuit(3)
-    for edge in [(0,1),(1,2),(1,2),(0,2),(0,2),(0,2)]:
+    for edge in [(0, 1), (1, 2), (1, 2), (0, 2), (0, 2), (0, 2)]:
         circuit.append_gate(CNOTGate(), edge)
 
-    circ,data = compiler.compile(
-        circuit,[partitioner, analyzer], request_data=True
+    _, data = compiler.compile(
+        circuit, [partitioner, analyzer], request_data=True,
     )
 
     structures = data['structures']
@@ -26,4 +24,3 @@ def test_list_structures(compiler: Compiler) -> None:
     assert structures[0].depth == 1
     assert structures[1].depth == 2
     assert structures[2].depth == 3
-

--- a/tests/passes/util/test_structure.py
+++ b/tests/passes/util/test_structure.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from bqskit.compiler.compiler import Compiler
+from bqskit.ir.circuit import Circuit
+from bqskit.ir.gates import CircuitGate
+from bqskit.ir.gates.constant.cx import CNOTGate
+from bqskit.passes import ExtendBlockSizePass
+from bqskit.passes import QuickPartitioner
+from bqskit.passes.util.structure import StructurePass
+
+
+def test_list_structures(compiler: Compiler) -> None:
+
+    partitioner = QuickPartitioner(2)
+    analyzer = StructurePass()
+    circuit = Circuit(3)
+    for edge in [(0,1),(1,2),(1,2),(0,2),(0,2),(0,2)]:
+        circuit.append_gate(CNOTGate(), edge)
+
+    circ,data = compiler.compile(
+        circuit,[partitioner, analyzer], request_data=True
+    )
+
+    structures = data['structures']
+    assert len(structures) == 3
+    assert structures[0].depth == 1
+    assert structures[1].depth == 2
+    assert structures[2].depth == 3
+

--- a/tests/passes/util/test_structure.py
+++ b/tests/passes/util/test_structure.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from bqskit.compiler.compiler import Compiler
 from bqskit.ir.circuit import Circuit
+from bqskit.ir.structure import CircuitStructure
 from bqskit.ir.gates.constant.cx import CNOTGate
 from bqskit.passes import QuickPartitioner
 from bqskit.passes.util.structure import StructureAnalysisPass
@@ -12,15 +13,24 @@ def test_list_structures(compiler: Compiler) -> None:
     partitioner = QuickPartitioner(2)
     analyzer = StructureAnalysisPass()
     circuit = Circuit(3)
+
+    true_structures = []
+    num_blocks = 3
+    for block_num in range(num_blocks):
+        block = Circuit(2)
+        for _ in range(block_num+1):
+            block.append_gate(CNOTGate(), (0, 1))
+        structure = CircuitStructure(block)
+        true_structures.append(structure)
+
     for edge in [(0, 1), (1, 2), (1, 2), (0, 2), (0, 2), (0, 2)]:
         circuit.append_gate(CNOTGate(), edge)
-
     _, data = compiler.compile(
         circuit, [partitioner, analyzer], request_data=True,
     )
 
-    structures = data['structures']
-    assert len(structures) == 3
-    assert structures[0].depth == 1
-    assert structures[1].depth == 2
-    assert structures[2].depth == 3
+    pass_structures = data['structures']
+    assert len(pass_structures) == 3
+    assert pass_structures[0] == true_structures[0]
+    assert pass_structures[1] == true_structures[1]
+    assert pass_structures[2] == true_structures[2]

--- a/tests/passes/util/test_structure.py
+++ b/tests/passes/util/test_structure.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from bqskit.compiler.compiler import Compiler
 from bqskit.ir.circuit import Circuit
-from bqskit.ir.structure import CircuitStructure
 from bqskit.ir.gates.constant.cx import CNOTGate
+from bqskit.ir.structure import CircuitStructure
 from bqskit.passes import QuickPartitioner
 from bqskit.passes.util.structure import StructureAnalysisPass
 
@@ -18,7 +18,7 @@ def test_list_structures(compiler: Compiler) -> None:
     num_blocks = 3
     for block_num in range(num_blocks):
         block = Circuit(2)
-        for _ in range(block_num+1):
+        for _ in range(block_num + 1):
             block.append_gate(CNOTGate(), (0, 1))
         structure = CircuitStructure(block)
         true_structures.append(structure)

--- a/tests/passes/util/test_structure.py
+++ b/tests/passes/util/test_structure.py
@@ -25,12 +25,12 @@ def test_list_structures(compiler: Compiler) -> None:
 
     for edge in [(0, 1), (1, 2), (1, 2), (0, 2), (0, 2), (0, 2)]:
         circuit.append_gate(CNOTGate(), edge)
-    _, data = compiler.compile(
+    circuit, data = compiler.compile(
         circuit, [partitioner, analyzer], request_data=True,
     )
 
     pass_structures = data['structures']
     assert len(pass_structures) == 3
-    assert pass_structures[0] == true_structures[0]
-    assert pass_structures[1] == true_structures[1]
-    assert pass_structures[2] == true_structures[2]
+    for ts, ps in zip(true_structures, pass_structures.keys()):
+        assert ts == ps
+        assert pass_structures[ps] == 1


### PR DESCRIPTION
Contains changes to the `SeedLayerGenerator` to make going backwards up the synthesis tree possible. Also created a `StructureAnalysisPass` which stores structures in `CircuitGate`s for later analysis. Also contains changes to the `QSearchSynthesisPass` so that seed circuits can be used to accelerate synthesis.