### PR TITLE
Small fix to make PAM work for different gate sets

### DIFF
--- a/bqskit/passes/mapping/embed.py
+++ b/bqskit/passes/mapping/embed.py
@@ -135,7 +135,7 @@ class EmbedAllPermutationsPass(BasePass):
 
         datas = []
         for graph in graphs:
-            model = MachineModel(circuit.num_qudits, graph)
+            model = MachineModel(circuit.num_qudits, graph, data.gate_set, data.model.radixes)
             target_data = copy.deepcopy(data)
             target_data.model = model
             datas.append(target_data)


### PR DESCRIPTION
Need to pass in the model gate set when creating the new graphs in order for the synthesis algorithms to correctly generate layers.