### PR TITLE
Support for Canonical Unitaries

### DIFF
--- a/bqskit/utils/math.py
+++ b/bqskit/utils/math.py
@@ -223,3 +223,37 @@ def compute_su_generators(n: int) -> npt.NDArray[np.complex128]:
         t3 *= np.sqrt(2 / (n * (n - 1)))
         generators.append(t3)
         return np.array(generators, dtype=np.complex128)
+
+
+def canonical_unitary(
+    unitary: npt.NDArray[np.complex128],
+) -> npt.NDArray[np.complex128]:
+    """
+    Computes a canonical form for the provided unitary.
+
+    If unitary matrices V, W differ only by a global phase, then
+    canonical_unitary(V) == canonical_unitary(W).
+
+    Args:
+        unitary (npt.NDArray[np.complex128]): A unitary matrix.
+
+    Returns:
+        npt.NDArray[np.complex128]: A unitary matrix.
+
+    References:
+        https://arxiv.org/abs/2306.05622
+    """
+    determinant = np.linalg.det(unitary)
+    dimension = len(unitary)
+    # Compute special unitary
+    global_phase = np.angle(determinant) / dimension
+    global_phase = global_phase % (2 * np.pi / dimension)
+    global_phase_factor = np.exp(-1j * global_phase)
+    special_unitary = global_phase_factor * unitary
+    # Standardize speical unitary to account for exp(-i2pi/N) differences
+    first_row_mags = np.linalg.norm(special_unitary[0, :], ord=2)
+    index = np.argmax(first_row_mags)
+    std_phase = np.angle(special_unitary[0, index])
+    correction_phase = 0 - std_phase
+    std_correction = np.exp(1j * correction_phase)
+    return std_correction * special_unitary

--- a/tests/utils/test_math.py
+++ b/tests/utils/test_math.py
@@ -10,6 +10,7 @@ import scipy as sp
 from scipy.stats import unitary_group
 
 from bqskit.qis.pauli import PauliMatrices
+from bqskit.utils.math import canonical_unitary
 from bqskit.utils.math import dexpmv
 from bqskit.utils.math import dot_product
 from bqskit.utils.math import pauli_expansion
@@ -185,3 +186,28 @@ class TestPauliExpansion:
         print(alpha)
         H = PauliMatrices(int(np.log2(reH.shape[0]))).dot_product(alpha)
         assert np.linalg.norm(H - reH) < 1e-16
+
+
+class TestCanonicalUnitary:
+    def random_phase(self) -> np.complex128:
+        phase = 2 * np.pi * np.random.rand()
+        return np.exp(1j * phase)
+
+    def assert_closeness(
+        self,
+        unitaries: list[npt.NDArray[np.complex128]],
+    ) -> None:
+        for u in unitaries:
+            for v in unitaries:
+                assert np.allclose(u, v, atol=1e-5)
+
+    def test_canonical_unitary(self) -> None:
+        num_phases = 100
+        for num_qubits in range(1, 5):
+            base_unitary = unitary_group.rvs(2**num_qubits)
+            phases = [self.random_phase() for _ in range(num_phases)]
+            unitaries = [phase * base_unitary for phase in phases]
+            canonical_unitaries = [
+                canonical_unitary(unitary) for unitary in unitaries
+            ]
+            self.assert_closeness(canonical_unitaries)

--- a/tests/utils/test_math.py
+++ b/tests/utils/test_math.py
@@ -189,25 +189,20 @@ class TestPauliExpansion:
 
 
 class TestCanonicalUnitary:
-    def random_phase(self) -> np.complex128:
-        phase = 2 * np.pi * np.random.rand()
-        return np.exp(1j * phase)
-
-    def assert_closeness(
+    @pytest.mark.parametrize(
+        'phase, num_qudits',
+        [
+            (np.exp(1j * 2 * np.pi * np.random.randn()), qudits)
+            for qudits in range(1, 6) for _ in range(100)
+        ],
+    )
+    def test_canonical_unitary(
         self,
-        unitaries: list[npt.NDArray[np.complex128]],
+        phase: np.complex128,
+        num_qudits: int,
     ) -> None:
-        for u in unitaries:
-            for v in unitaries:
-                assert np.allclose(u, v, atol=1e-5)
-
-    def test_canonical_unitary(self) -> None:
-        num_phases = 100
-        for num_qubits in range(1, 5):
-            base_unitary = unitary_group.rvs(2**num_qubits)
-            phases = [self.random_phase() for _ in range(num_phases)]
-            unitaries = [phase * base_unitary for phase in phases]
-            canonical_unitaries = [
-                canonical_unitary(unitary) for unitary in unitaries
-            ]
-            self.assert_closeness(canonical_unitaries)
+        base_unitary = unitary_group.rvs(2**num_qudits)
+        canon_unitary = canonical_unitary(base_unitary)
+        phased_unitary = phase * base_unitary
+        recanon_unitary = canonical_unitary(phased_unitary)
+        assert np.allclose(canon_unitary, recanon_unitary, atol=1e-5)


### PR DESCRIPTION
Adds the `canonical_unitary` function to `bqskit/utils/math.py`. Ensures that unitaries that differ only by a global phase are cast to the same matrix representation.