### PR TITLE
Feature: Cache for runtime workers

### DIFF
--- a/bqskit/passes/search/generators/seed.py
+++ b/bqskit/passes/search/generators/seed.py
@@ -27,7 +27,7 @@ class SeedLayerGenerator(LayerGenerator):
         seed: Circuit | Sequence[Circuit],
         forward_generator: LayerGenerator = SimpleLayerGenerator(),
         num_removed: int = 1,
-        hash_on_1q_gate: bool = True,
+        hash_on_1q_gate: bool = False,
     ) -> None:
         """
         Construct a SeedLayerGenerator.

--- a/bqskit/runtime/__init__.py
+++ b/bqskit/runtime/__init__.py
@@ -162,6 +162,16 @@ class RuntimeHandle(Protocol):
         """
         ...
 
+    def get_cache(self) -> dict[str, Any]:
+        """
+        Retrieve worker's local cache.
+
+        A worker's local cache is implemented as a dictionary. This function
+        can be used to check the presence of data, or to place data directly
+        into, a worker's local cache.
+        """
+        ...
+
     async def next(self, future: RuntimeFuture) -> list[tuple[int, Any]]:
         """
         Wait for and return the next batch of results from a map task.

--- a/bqskit/runtime/__init__.py
+++ b/bqskit/runtime/__init__.py
@@ -166,9 +166,9 @@ class RuntimeHandle(Protocol):
         """
         Retrieve worker's local cache.
 
-        A worker's local cache is implemented as a dictionary. This function
-        can be used to check the presence of data, or to place data directly
-        into, a worker's local cache.
+        A worker's local cache is implemented as a dictionary. This function can
+        be used to check the presence of data, or to place data directly into, a
+        worker's local cache.
         """
         ...
 

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -495,8 +495,7 @@ class Worker:
             fnarg,
             RuntimeAddress(self._id, mailbox_id, 0),
             self._active_task.comp_task_id,
-            self._active_task.breadcrumbs +
-            (self._active_task.return_address,),
+            self._active_task.breadcrumbs + (self._active_task.return_address,),
             self._active_task.logging_level,
             self._active_task.max_logging_depth,
         )

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -576,8 +576,7 @@ class Worker:
                 worker process' memory. Passes on the same worker that use
                 the same object can load the object from this cache. If
                 there are multiple workers, those workers will load their
-                own copies of the object into their own cache. This happens
-                because all workers are assumed to be identical.
+                own copies of the object into their own cache.
         """
         return self._cache
 

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -571,8 +571,13 @@ class Worker:
         Retrieve worker's local cache.
 
         Returns:
-            (dict[str, Any]): The worker's local cache implemented
-                with a dictionary.
+            (dict[str, Any]): The worker's local cache. This cache can be
+                used to store large or unserializable objects within a
+                worker process' memory. Passes on the same worker that use
+                the same object can load the object from this cache. If
+                there are multiple workers, those workers will load their
+                own copies of the object into their own cache. This happens
+                because all workers are assumed to be identical.
         """
         return self._cache
 

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -205,6 +205,9 @@ class Worker:
         self._mailbox_counter = 0
         """This count ensures every mailbox has a unique id."""
 
+        self._cache: dict[str, Any] = {}
+        """Local worker cache."""
+
         # Send out every emitted log message upstream
         old_factory = logging.getLogRecordFactory()
 
@@ -492,7 +495,8 @@ class Worker:
             fnarg,
             RuntimeAddress(self._id, mailbox_id, 0),
             self._active_task.comp_task_id,
-            self._active_task.breadcrumbs + (self._active_task.return_address,),
+            self._active_task.breadcrumbs +
+            (self._active_task.return_address,),
             self._active_task.logging_level,
             self._active_task.max_logging_depth,
         )
@@ -562,6 +566,16 @@ class Worker:
         ]
         msgs = [(RuntimeMessage.CANCEL, addr) for addr in addrs]
         self._outgoing.extend(msgs)
+
+    def get_cache(self) -> dict[str, Any]:
+        """
+        Retrieve worker's local cache.
+
+        Returns:
+            (dict[str, Any]): The worker's local cache implemented
+                with a dictionary.
+        """
+        return self._cache
 
     async def next(self, future: RuntimeFuture) -> list[tuple[int, Any]]:
         """

--- a/tests/runtime/test_cache.py
+++ b/tests/runtime/test_cache.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import numpy as np
+
+from bqskit.compiler import BasePass
+from bqskit.compiler import Compiler
+from bqskit.compiler.passdata import PassData
+from bqskit.ir.circuit import Circuit
+from bqskit.runtime import get_runtime
+from bqskit.passes.util.update import UpdateDataPass
+
+
+def random_np_array() -> np.ndarray:
+    return np.random.randn(4, 4, 4)
+
+
+class TestWorkerCachePut(BasePass):
+    async def run(self, circuit: Circuit, data: PassData) -> None:
+        handle = get_runtime()
+        cache = handle.get_cache()
+        cache['random_array'] = data['random_array_put']
+
+
+class TestWorkerCacheGet(BasePass):
+    async def run(self, circuit: Circuit, data: PassData) -> None:
+        handle = get_runtime()
+        cache = handle.get_cache()
+        data['random_array_get'] = cache['random_array']
+
+
+def test_simple_put_and_get(server_compiler: Compiler) -> None:
+    circuit = Circuit(2)
+    passes = [
+        UpdateDataPass('random_array_put', random_np_array()),
+        TestWorkerCachePut(),
+        TestWorkerCacheGet(),
+    ]
+    circuit, data = server_compiler.compile(circuit, passes, request_data=True)
+    putted = data['random_array_put']
+    gotten = data['random_array_get']
+    assert (putted == gotten).all()

--- a/tests/runtime/test_cache.py
+++ b/tests/runtime/test_cache.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
-import numpy as np
+from numpy import float64
+from numpy.random import randn
+from numpy.typing import NDArray
 
 from bqskit.compiler import BasePass
 from bqskit.compiler import Compiler
 from bqskit.compiler.passdata import PassData
 from bqskit.ir.circuit import Circuit
-from bqskit.runtime import get_runtime
 from bqskit.passes.util.update import UpdateDataPass
+from bqskit.runtime import get_runtime
 
 
-def random_np_array() -> np.ndarray:
-    return np.random.randn(4, 4, 4)
+def random_np_array() -> NDArray[float64]:
+    return randn(4, 4, 4)
 
 
 class TestWorkerCachePut(BasePass):


### PR DESCRIPTION
This PR adds the ability to interact with a "runtime cache" for workers. Objects that are not CPickle-able (such as Pytorch modules) can instead be loaded to cache. Doing so ensures that objects are only loaded by each worker a single time. The cache is implemented as a simple Python dictionary.

Use:
In a worker process, items in worker cache can be accessed using the following general outline:
```
from bqskit.runtime import get_runtime

worker_cache = get_runtime().get_cache()

if 'object_name' not in worker_cache:
    object = load_object()
    worker_cache['object_name'] = object
else:
    object = worker_cache['object_name']
```