### PR TITLE
Hash structure of only multi-qubit gates

### DIFF
--- a/bqskit/passes/search/generators/seed.py
+++ b/bqskit/passes/search/generators/seed.py
@@ -168,6 +168,8 @@ class SeedLayerGenerator(LayerGenerator):
     def hash_structure(circuit: Circuit) -> int:
         hashes = []
         for cycle, op in circuit.operations_with_cycles():
+            if op.num_qudits <= 1:
+                continue
             hashes.append(hash((cycle, str(op))))
             if len(hashes) > 100:
                 hashes = [sum(hashes)]


### PR DESCRIPTION
The `hash_structure` function in the `SeedLayerGenerator` assigns a unique hash to each circuit structure. Due to possible mismatches between the 1Q gates used in seed circuits and the 1Q gates used in the internal `layer_gen`, synthesis may revisit the same structure many times.

Example:
A seed circuit with CNOTs at locations [(0,1), (1,2), (1,2)] has U3 gates after each CNOT application. Depending on the layer generator assigned by `_get_layer_gen` in QSearch, multiple 1Q gates may follow each of the U3 gates. These extra 1Q gates impact the circuit structure's hash so that the same structure may be revisited multiple times. This change ensures that only multi-qubit gates are involved in determining the hash of the circuit's structure.