### PR TITLE
Fix identity rebase

### DIFF
--- a/bqskit/compiler/compile.py
+++ b/bqskit/compiler/compile.py
@@ -1014,7 +1014,7 @@ def build_multi_qudit_retarget_workflow(
                     ),
                     RestoreModelConnevtivityPass(),
                 ],
-                AutoRebase2QuditGatePass(3, 5),
+                AutoRebase2QuditGatePass(3, 5, synthesis_epsilon),
             ),
             ScanningGateRemovalPass(
                 success_threshold=synthesis_epsilon,

--- a/bqskit/passes/retarget/auto.py
+++ b/bqskit/passes/retarget/auto.py
@@ -6,10 +6,10 @@ from typing import Any
 
 from bqskit.compiler.passdata import PassData
 from bqskit.ir.circuit import Circuit
-from bqskit.qis.unitary import UnitaryMatrix
 from bqskit.ir.opt.cost.functions import HilbertSchmidtResidualsGenerator
 from bqskit.ir.opt.cost.generator import CostFunctionGenerator
 from bqskit.passes.retarget.two import Rebase2QuditGatePass
+from bqskit.qis.unitary import UnitaryMatrix
 from bqskit.runtime import get_runtime
 from bqskit.utils.typing import is_integer
 from bqskit.utils.typing import is_real_number
@@ -113,11 +113,12 @@ class AutoRebase2QuditGatePass(Rebase2QuditGatePass):
 
         target = self.get_target(circuit, data)
 
-        identity = UnitaryMatrix.identity(target.dim, target.radixes)
-        if target.get_distance_from(identity) < self.success_threshold:
-            _logger.debug('Target is identity, returning empty circuit.')
-            circuit.clear()
-            return
+        if isinstance(target, UnitaryMatrix):
+            identity = UnitaryMatrix.identity(target.dim, target.radixes)
+            if target.get_distance_from(identity) < self.success_threshold:
+                _logger.debug('Target is identity, returning empty circuit.')
+                circuit.clear()
+                return
 
         for g in old_gates:
             # Track retries to check for no progress

--- a/bqskit/passes/retarget/auto.py
+++ b/bqskit/passes/retarget/auto.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from bqskit.compiler.passdata import PassData
 from bqskit.ir.circuit import Circuit
+from bqskit.qis.unitary import UnitaryMatrix
 from bqskit.ir.opt.cost.functions import HilbertSchmidtResidualsGenerator
 from bqskit.ir.opt.cost.generator import CostFunctionGenerator
 from bqskit.passes.retarget.two import Rebase2QuditGatePass
@@ -111,6 +112,12 @@ class AutoRebase2QuditGatePass(Rebase2QuditGatePass):
         _logger.debug(f'Rebasing gates from {old_gates} to {new_gates}.')
 
         target = self.get_target(circuit, data)
+
+        identity = UnitaryMatrix.identity(target.dim, target.radixes)
+        if target.get_distance_from(identity) < self.success_threshold:
+            _logger.debug('Target is identity, returning empty circuit.')
+            circuit.clear()
+            return
 
         for g in old_gates:
             # Track retries to check for no progress

--- a/bqskit/passes/retarget/two.py
+++ b/bqskit/passes/retarget/two.py
@@ -13,6 +13,7 @@ from bqskit.ir.gates.parameterized.u3 import U3Gate
 from bqskit.ir.opt.cost.functions import HilbertSchmidtResidualsGenerator
 from bqskit.ir.opt.cost.generator import CostFunctionGenerator
 from bqskit.ir.point import CircuitPoint as Point
+from bqskit.qis.unitary import UnitaryMatrix
 from bqskit.runtime import get_runtime
 from bqskit.utils.typing import is_integer
 from bqskit.utils.typing import is_real_number
@@ -164,6 +165,12 @@ class Rebase2QuditGatePass(BasePass):
 
         target = self.get_target(circuit, data)
 
+        identity = UnitaryMatrix.identity(target.dim, target.radixes)
+        if target.get_distance_from(identity) < self.success_threshold:
+            _logger.debug('Target is identity, returning empty circuit.')
+            circuit.clear()
+            return
+
         for g in self.gates:
             # Track retries to check for no progress
             num_retries = 0
@@ -188,6 +195,7 @@ class Rebase2QuditGatePass(BasePass):
                     circuit.point(g),
                     self.gates,
                 )
+
                 circuits_with_new_gate = []
                 for circ in self.circs:
                     circuit_copy = circuit.copy()

--- a/bqskit/passes/retarget/two.py
+++ b/bqskit/passes/retarget/two.py
@@ -165,11 +165,12 @@ class Rebase2QuditGatePass(BasePass):
 
         target = self.get_target(circuit, data)
 
-        identity = UnitaryMatrix.identity(target.dim, target.radixes)
-        if target.get_distance_from(identity) < self.success_threshold:
-            _logger.debug('Target is identity, returning empty circuit.')
-            circuit.clear()
-            return
+        if isinstance(target, UnitaryMatrix):
+            identity = UnitaryMatrix.identity(target.dim, target.radixes)
+            if target.get_distance_from(identity) < self.success_threshold:
+                _logger.debug('Target is identity, returning empty circuit.')
+                circuit.clear()
+                return
 
         for g in self.gates:
             # Track retries to check for no progress

--- a/tests/compiler/compile/test_corner_cases.py
+++ b/tests/compiler/compile/test_corner_cases.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from bqskit.compiler.compile import compile
 from bqskit.compiler.compiler import Compiler
 from bqskit.ir.lang.qasm2 import OPENQASM2Language
 
 
-def test_cry_identity_corner_case(compiler: Compiler):
+def test_cry_identity_corner_case(compiler: Compiler) -> None:
     qasm = """
         OPENQASM 2.0;
         include "qelib1.inc";
@@ -15,4 +17,3 @@ def test_cry_identity_corner_case(compiler: Compiler):
     circuit = OPENQASM2Language().decode(qasm)
     _ = compile(circuit, optimization_level=1, seed=10)
     # Should finish
-

--- a/tests/compiler/compile/test_corner_cases.py
+++ b/tests/compiler/compile/test_corner_cases.py
@@ -1,0 +1,18 @@
+from bqskit.compiler.compile import compile
+from bqskit.compiler.compiler import Compiler
+from bqskit.ir.lang.qasm2 import OPENQASM2Language
+
+
+def test_cry_identity_corner_case(compiler: Compiler):
+    qasm = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[5];
+        creg meas[5];
+        cry(0) q[0],q[2];
+        cry(0) q[1],q[2];
+    """
+    circuit = OPENQASM2Language().decode(qasm)
+    _ = compile(circuit, optimization_level=1, seed=10)
+    # Should finish
+


### PR DESCRIPTION
Fixes #217 by 1) passing synthesis epsilon to the rebasing passes in the standard compilation workflow and 2) detecting identity rebasing and handling it specially.

It seems like our standard numerical instantiation pipelines had particular difficulty solving for the identity in the specific CRY case listed in #217.