### PR TITLE
Runtime updates

### DIFF
--- a/bqskit/__init__.py
+++ b/bqskit/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from sys import stdout as _stdout
 
+import bqskit.runtime
 from .version import __version__  # noqa: F401
 from .version import __version_info__  # noqa: F401
 from bqskit.compiler.compile import compile

--- a/bqskit/runtime/__init__.py
+++ b/bqskit/runtime/__init__.py
@@ -111,7 +111,7 @@ os.environ['MKL_NUM_THREADS'] = '1'
 os.environ['NUMEXPR_NUM_THREADS'] = '1'
 os.environ['VECLIB_MAXIMUM_THREADS'] = '1'
 os.environ['RUST_BACKTRACE'] = '1'
-
+print("SETTING THREADS TO 1")
 
 if TYPE_CHECKING:
     from bqskit.runtime.future import RuntimeFuture

--- a/bqskit/runtime/__init__.py
+++ b/bqskit/runtime/__init__.py
@@ -111,7 +111,7 @@ os.environ['MKL_NUM_THREADS'] = '1'
 os.environ['NUMEXPR_NUM_THREADS'] = '1'
 os.environ['VECLIB_MAXIMUM_THREADS'] = '1'
 os.environ['RUST_BACKTRACE'] = '1'
-print("SETTING THREADS TO 1")
+print('SETTING THREADS TO 1')
 
 if TYPE_CHECKING:
     from bqskit.runtime.future import RuntimeFuture

--- a/bqskit/runtime/base.py
+++ b/bqskit/runtime/base.py
@@ -52,8 +52,9 @@ class RuntimeEmployee:
         self.submit_cache: list[tuple[RuntimeAddress, int]] = []
         """
         Tracks recently submitted tasks by id and count.
-        This is used to adjust the idle worker count when
-        the employee sends a waiting message.
+
+        This is used to adjust the idle worker count when the employee sends a
+        waiting message.
         """
 
     def shutdown(self) -> None:
@@ -595,13 +596,12 @@ class ServerBase:
         """
         Record that an employee is idle with nothing to do.
 
-        There is a race condition that is corrected here. If an employee
-        sends a waiting message at the same time that its boss sends it a
-        task, the boss's idle count will eventually be incorrect. To fix
-        this, every waiting message sent by an employee is accompanied by
-        a read receipt of the latest batch of tasks it has processed. The
-        boss can then adjust the idle count by the number of tasks sent
-        since the read receipt.
+        There is a race condition that is corrected here. If an employee sends a
+        waiting message at the same time that its boss sends it a task, the
+        boss's idle count will eventually be incorrect. To fix this, every
+        waiting message sent by an employee is accompanied by a read receipt of
+        the latest batch of tasks it has processed. The boss can then adjust the
+        idle count by the number of tasks sent since the read receipt.
         """
         employee = self.conn_to_employee_dict[conn]
         unaccounted_task = employee.get_num_of_tasks_sent_since(read_receipt)

--- a/bqskit/runtime/detached.py
+++ b/bqskit/runtime/detached.py
@@ -15,6 +15,7 @@ from threading import Thread
 from typing import Any
 from typing import cast
 from typing import List
+from typing import Optional
 from typing import Sequence
 
 from bqskit.compiler.status import CompilationStatus
@@ -182,7 +183,8 @@ class DetachedServer(ServerBase):
                 self.handle_shutdown()
 
             elif msg == RuntimeMessage.WAITING:
-                num_idle, read_receipt = cast(int, payload)
+                p = cast(tuple[int, Optional[RuntimeAddress]], payload)
+                num_idle, read_receipt = p
                 self.handle_waiting(conn, num_idle, read_receipt)
 
             elif msg == RuntimeMessage.UPDATE:

--- a/bqskit/runtime/detached.py
+++ b/bqskit/runtime/detached.py
@@ -182,8 +182,8 @@ class DetachedServer(ServerBase):
                 self.handle_shutdown()
 
             elif msg == RuntimeMessage.WAITING:
-                num_idle = cast(int, payload)
-                self.handle_waiting(conn, num_idle)
+                num_idle, read_receipt = cast(int, payload)
+                self.handle_waiting(conn, num_idle, read_receipt)
 
             elif msg == RuntimeMessage.UPDATE:
                 task_diff = cast(int, payload)

--- a/bqskit/runtime/manager.py
+++ b/bqskit/runtime/manager.py
@@ -95,14 +95,16 @@ class Manager(ServerBase):
             MessageDirection.ABOVE,
         )
 
-        # Case 1: spawn and manage workers
+        # Case 1: spawn and/or manage workers
         if ipports is None:
             if only_connect:
                 self.connect_to_workers(num_workers, worker_port)
             else:
+                print('Spawning workers...')
+                print(f'Number of workers: {num_workers}')
                 self.spawn_workers(num_workers, worker_port)
 
-        # Case 2: Connect to managers at ipports
+        # Case 2: Connect to detached managers at ipports
         else:
             self.connect_to_managers(ipports)
 
@@ -122,6 +124,7 @@ class Manager(ServerBase):
         payload: Any,
     ) -> None:
         """Process the message coming from `direction`."""
+        self.logger.debug(f'Manager handling message {msg.name} from {direction.name}.')
         if direction == MessageDirection.ABOVE:
 
             if msg == RuntimeMessage.SUBMIT:
@@ -133,6 +136,7 @@ class Manager(ServerBase):
                 rtasks = cast(List[RuntimeTask], payload)
                 self.schedule_tasks(rtasks)
                 self.update_upstream_idle_workers()
+                self.logger.debug(f'Finished handling submit batch from above.')
 
             elif msg == RuntimeMessage.RESULT:
                 result = cast(RuntimeResult, payload)

--- a/bqskit/runtime/manager.py
+++ b/bqskit/runtime/manager.py
@@ -9,6 +9,7 @@ from multiprocessing.connection import Connection
 from typing import Any
 from typing import cast
 from typing import List
+from typing import Optional
 from typing import Sequence
 
 from bqskit.runtime import default_manager_port
@@ -170,7 +171,8 @@ class Manager(ServerBase):
                 self.handle_result_from_below(result)
 
             elif msg == RuntimeMessage.WAITING:
-                num_idle, read_receipt = cast(int, payload)
+                p = cast(tuple[int, Optional[RuntimeAddress]], payload)
+                num_idle, read_receipt = p
                 self.handle_waiting(conn, num_idle, read_receipt)
                 self.update_upstream_idle_workers()
 

--- a/bqskit/runtime/task.py
+++ b/bqskit/runtime/task.py
@@ -28,7 +28,7 @@ class RuntimeTask:
 
     def __init__(
         self,
-        fnargs: tuple[Any, Any, Any],
+        fnargs: tuple[Any, Any, Any],  # TODO: Look into retyping this
         return_address: RuntimeAddress,
         comp_task_id: int,
         breadcrumbs: tuple[RuntimeAddress, ...],
@@ -110,3 +110,11 @@ class RuntimeTask:
     def is_descendant_of(self, addr: RuntimeAddress) -> bool:
         """Return true if `addr` identifies a parent (or this) task."""
         return addr == self.return_address or addr in self.breadcrumbs
+
+    def __str__(self) -> str:
+        """Return a string representation of the task."""
+        return f'{self.fnargs[0].__name__}'
+
+    def __repr__(self) -> str:
+        """Return a string representation of the task."""
+        return f'<RuntimeTask {self.task_id} {self.fnargs[0].__name__}>'

--- a/bqskit/runtime/task.py
+++ b/bqskit/runtime/task.py
@@ -45,6 +45,7 @@ class RuntimeTask:
         self.return_address = return_address
         """
         Where the result of this task should be sent.
+
         This doubles as a unique system-wide id for the task.
         """
 

--- a/bqskit/runtime/task.py
+++ b/bqskit/runtime/task.py
@@ -43,7 +43,10 @@ class RuntimeTask:
         """Tuple of function pointer, arguments, and keyword arguments."""
 
         self.return_address = return_address
-        """Where the result of this task should be sent."""
+        """
+        Where the result of this task should be sent.
+        This doubles as a unique system-wide id for the task.
+        """
 
         self.logging_level = logging_level
         """Logs with levels >= to this get emitted, if None always emit."""
@@ -96,6 +99,11 @@ class RuntimeTask:
         logging.getLogger().setLevel(old_level)
 
         return to_return
+
+    @property
+    def unique_id(self) -> RuntimeAddress:
+        """Return the task's system-wide unique id."""
+        return self.return_address
 
     def start(self) -> None:
         """Initialize the task."""


### PR DESCRIPTION
Improves the runtime by addressing some shortcomings that cause issues in rare situations:
- Splits the single-threaded worker into two threads: one thread does work, while one consumes incoming messages. This prevents the rx buffer from filling up and blocking other parts of the system while the worker is working on a long job.
- Added read receipts to the waiting messages to create a "happens-before" relationship with certain messages. This ensures eventual consistency with idle worker tracking through the system and avoids a previously allowed race condition. Moreover, the manager can now always adjust their idle count to an accurate amount.
- Workers now send messages instantly rather than waiting until their current job has finished or enters an awaited state. This allows for child tasks to start quicker and log messages to appear instantly.

...draft...more to come