### PR TITLE
Implemented `__del__` to clean up hanging coroutines

### DIFF
--- a/bqskit/runtime/task.py
+++ b/bqskit/runtime/task.py
@@ -104,6 +104,10 @@ class RuntimeTask:
     def cancel(self) -> None:
         """Ask the coroutine to gracefully exit."""
         if self.coro is not None:
+            # If this call to "close" raises a RuntimeError,
+            # it is likely a blanket try/accept catching the
+            # error used to stop the coroutine, preventing
+            # it from stopping correctly.
             self.coro.close()
         else:
             raise RuntimeError('Task was cancelled with None coroutine.')

--- a/bqskit/runtime/task.py
+++ b/bqskit/runtime/task.py
@@ -103,7 +103,10 @@ class RuntimeTask:
 
     def cancel(self) -> None:
         """Ask the coroutine to gracefully exit."""
-        self.coro.close()
+        if self.coro is not None:
+            self.coro.close()
+        else:
+            raise RuntimeError('Task was cancelled before its coroutine was started.')
 
     async def run(self) -> Any:
         """Task coroutine wrapper."""

--- a/bqskit/runtime/task.py
+++ b/bqskit/runtime/task.py
@@ -103,8 +103,7 @@ class RuntimeTask:
 
     def cancel(self) -> None:
         """Ask the coroutine to gracefully exit."""
-        if self.coro is not None:
-            self.coro.close()
+        self.coro.close()
 
     async def run(self) -> Any:
         """Task coroutine wrapper."""

--- a/bqskit/runtime/task.py
+++ b/bqskit/runtime/task.py
@@ -115,4 +115,3 @@ class RuntimeTask:
     def is_descendant_of(self, addr: RuntimeAddress) -> bool:
         """Return true if `addr` identifies a parent (or this) task."""
         return addr == self.return_address or addr in self.breadcrumbs
-

--- a/bqskit/runtime/task.py
+++ b/bqskit/runtime/task.py
@@ -101,6 +101,11 @@ class RuntimeTask:
         """Initialize the task."""
         self.coro = self.run()
 
+    def cancel(self) -> None:
+        """Ask the coroutine to gracefully exit."""
+        if self.coro is not None:
+            self.coro.close()
+
     async def run(self) -> Any:
         """Task coroutine wrapper."""
         if inspect.iscoroutinefunction(self.fnargs[0]):
@@ -111,7 +116,3 @@ class RuntimeTask:
         """Return true if `addr` identifies a parent (or this) task."""
         return addr == self.return_address or addr in self.breadcrumbs
 
-    def __del__(self) -> None:
-        """Close the coroutine to make sure it is not left hanging."""
-        if self.coro is not None:
-            self.coro.close()

--- a/bqskit/runtime/task.py
+++ b/bqskit/runtime/task.py
@@ -106,7 +106,7 @@ class RuntimeTask:
         if self.coro is not None:
             self.coro.close()
         else:
-            raise RuntimeError('Task was cancelled before its coroutine was started.')
+            raise RuntimeError('Task was cancelled with None coroutine.')
 
     async def run(self) -> Any:
         """Task coroutine wrapper."""

--- a/bqskit/runtime/task.py
+++ b/bqskit/runtime/task.py
@@ -110,3 +110,8 @@ class RuntimeTask:
     def is_descendant_of(self, addr: RuntimeAddress) -> bool:
         """Return true if `addr` identifies a parent (or this) task."""
         return addr == self.return_address or addr in self.breadcrumbs
+
+    def __del__(self) -> None:
+        """Close the coroutine to make sure it is not left hanging."""
+        if self.coro is not None:
+            self.coro.close()

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -328,9 +328,9 @@ class Worker:
         # Remove all tasks that are children of `addr` from initialized tasks
         for key, task in self._tasks.items():
             if task.is_descendant_of(addr):
+                task.cancel()
                 for mailbox_id in self._tasks[key].owned_mailboxes:
                     self._mailboxes.pop(mailbox_id)
-                task.cancel()
         self._tasks = {
             a: t for a, t in self._tasks.items()
             if not t.is_descendant_of(addr)
@@ -341,7 +341,6 @@ class Worker:
             t for t in self._delayed_tasks
             if not t.is_descendant_of(addr)
         ]
-
 
     def _get_next_ready_task(self) -> RuntimeTask | None:
         """Return the next ready task if one exists, otherwise None."""
@@ -500,7 +499,8 @@ class Worker:
             fnarg,
             RuntimeAddress(self._id, mailbox_id, 0),
             self._active_task.comp_task_id,
-            self._active_task.breadcrumbs + (self._active_task.return_address,),
+            self._active_task.breadcrumbs +
+            (self._active_task.return_address,),
             self._active_task.logging_level,
             self._active_task.max_logging_depth,
         )

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -498,9 +498,9 @@ class Worker:
         task = RuntimeTask(
             fnarg,
             RuntimeAddress(self._id, mailbox_id, 0),
-            self._active_task.comp_task_id,
-            self._active_task.breadcrumbs +
-            (self._active_task.return_address,),
+            + self._active_task.comp_task_id,
+            self._active_task.breadcrumbs
+            + (self._active_task.return_address,),
             self._active_task.logging_level,
             self._active_task.max_logging_depth,
         )

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -326,25 +326,30 @@ class Worker:
         self._cancelled_task_ids.add(addr)
 
         # Remove all tasks that are children of `addr` from initialized tasks
+        error = None
         for key, task in self._tasks.items():
             if task.is_descendant_of(addr):
                 for mailbox_id in self._tasks[key].owned_mailboxes:
                     self._mailboxes.pop(mailbox_id)
-                task.cancel()
+                try:
+                    task.cancel()
+                except Exception as e:
+                    if error is None:
+                        error = e
         self._tasks = {
             a: t for a, t in self._tasks.items()
             if not t.is_descendant_of(addr)
         }
 
         # Remove all tasks that are children of `addr` from delayed tasks
-        for task in self._delayed_tasks:
-            if task.is_descendant_of(addr):
-                task.cancel()
-
         self._delayed_tasks = [
             t for t in self._delayed_tasks
             if not t.is_descendant_of(addr)
         ]
+
+        # if there was an error earlier, raise it now
+        if error is not None:
+            raise error
 
     def _get_next_ready_task(self) -> RuntimeTask | None:
         """Return the next ready task if one exists, otherwise None."""

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -326,16 +326,11 @@ class Worker:
         self._cancelled_task_ids.add(addr)
 
         # Remove all tasks that are children of `addr` from initialized tasks
-        error = None
         for key, task in self._tasks.items():
             if task.is_descendant_of(addr):
                 for mailbox_id in self._tasks[key].owned_mailboxes:
                     self._mailboxes.pop(mailbox_id)
-                try:
-                    task.cancel()
-                except Exception as e:
-                    if error is None:
-                        error = e
+                task.cancel()
         self._tasks = {
             a: t for a, t in self._tasks.items()
             if not t.is_descendant_of(addr)
@@ -347,9 +342,6 @@ class Worker:
             if not t.is_descendant_of(addr)
         ]
 
-        # if there was an error earlier, raise it now
-        if error is not None:
-            raise error
 
     def _get_next_ready_task(self) -> RuntimeTask | None:
         """Return the next ready task if one exists, otherwise None."""

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -498,7 +498,7 @@ class Worker:
         task = RuntimeTask(
             fnarg,
             RuntimeAddress(self._id, mailbox_id, 0),
-            + self._active_task.comp_task_id,
+            self._active_task.comp_task_id,
             self._active_task.breadcrumbs
             + (self._active_task.return_address,),
             self._active_task.logging_level,


### PR DESCRIPTION
This is intended to be a simple fix for https://github.com/BQSKit/bqskit/issues/262

Currently, when `RuntimeTask`s are cancelled, they sometimes end up garbage collected with coroutines that are never `await`ed.  When those coroutines get garbage collected, `RuntimeWarning`s appear.

I've implemented `__del__` for `RuntimeTask` which simply `close()`s the coroutine, which lets Python know its ok that the coroutine was never used.