### PR TITLE
Handle EOFError and ConnectionResetError without chaining exceptions in server connection failure

### DIFF
--- a/bqskit/compiler/compiler.py
+++ b/bqskit/compiler/compiler.py
@@ -406,7 +406,12 @@ class Compiler:
         except Exception as e:
             self.conn = None
             self.close()
-            raise RuntimeError('Server connection unexpectedly closed.') from e
+            if isinstance(e, (EOFError, ConnectionResetError)):
+                raise RuntimeError('Server connection unexpectedly closed.')
+            else:
+                raise RuntimeError(
+                    'Server connection unexpectedly closed.',
+                ) from e
 
     def _send_recv(
         self,


### PR DESCRIPTION
This PR updates the exception handling logic in the client-server connection code. Specifically, it modifies how `EOFError` and `ConnectionResetError` are handled during connection failures. The goal is to avoid exception chaining (`from e`) for these specific error types, while maintaining chaining for all other exceptions.

## Changes

- Added conditional logic to raise `RuntimeError` without from e when the exception is `EOFError` or `ConnectionResetError`.

- For all other exceptions, the existing behavior (raising `RuntimeError` with `from e`) is preserved.

## Rationale

- `EOFError` and `ConnectionResetError `indicate specific situations where the connection is lost in a more predictable way (e.g., server gracfully closing the connection).

- Avoiding exception chaining for these cases provides a clearer stack trace, since the original exception doesn't add much value in these specific cases.

- For other unexpected errors, preserving `from e` helps retain context for debugging.