### PR TITLE
Adding general checkpointing infra to checkpoint inside a pass

### DIFF
--- a/bqskit/compiler/passdata.py
+++ b/bqskit/compiler/passdata.py
@@ -63,13 +63,14 @@ class PassData(MutableMapping[str, Any]):
     def target(self) -> StateVector | UnitaryMatrix | StateSystem:
         """Return the current target unitary or state."""
         if isinstance(self._target, Circuit):
-            self._target = self._target.get_unitary()
+            if self._target.num_qudits <= 8:
+                self._target = self._target.get_unitary()
 
         return self._target
 
     @target.setter
-    def target(self, _val: StateVector | UnitaryMatrix | StateSystem) -> None:
-        if not isinstance(_val, (StateVector, UnitaryMatrix, StateSystem)):
+    def target(self, _val: StateVector | UnitaryMatrix | StateSystem | Circuit) -> None:
+        if not isinstance(_val, (StateVector, UnitaryMatrix, StateSystem, Circuit)):
             raise TypeError(
                 f'Cannot assign type {type(_val)} to target.'
                 ' Expected either a StateVector, StateSystem,'
@@ -251,24 +252,6 @@ class PassData(MutableMapping[str, Any]):
         in_resv = self._reserved_keys.__contains__(_o)
         in_data = self._data.__contains__(_o)
         return in_resv or in_data
-
-    def update(self, other: Any = (), /, **kwds: Any) -> None:
-        """Update the data with key-values pairs from `other` and `kwds`."""
-        if isinstance(other, PassData):
-            for key in other:
-                # Handle target specially to avoid circuit evaluation
-                if key == 'target':
-                    self._target = other._target
-                    continue
-
-                self[key] = other[key]
-
-            for key, value in kwds.items():
-                self[key] = value
-
-            return
-
-        super().update(other, **kwds)
 
     def copy(self) -> PassData:
         """Returns a deep copy of the data."""

--- a/bqskit/passes/io/__init__.py
+++ b/bqskit/passes/io/__init__.py
@@ -1,12 +1,14 @@
 """This package implements various IO related passes."""
 from __future__ import annotations
 
+from bqskit.passes.io.intermediate import CheckpointRestartPass
 from bqskit.passes.io.checkpoint import LoadCheckpointPass
 from bqskit.passes.io.checkpoint import SaveCheckpointPass
 from bqskit.passes.io.intermediate import RestoreIntermediatePass
 from bqskit.passes.io.intermediate import SaveIntermediatePass
 
 __all__ = [
+    'CheckpointRestartPass',
     'LoadCheckpointPass',
     'SaveCheckpointPass',
     'SaveIntermediatePass',


### PR DESCRIPTION
These changes allow you to checkpoint subdirectories and make simple changes to checkpoint inside a long pass (such as ScanningGateRemoval on wide blocks). The changes include:

A new RestartCheckpointPass:
- This pass allows you to restart a workflow from a checkpoint. It is more flexible than RestoreIntermediatePass as it allows for sub-blocks to be loaded and performs default passes if a checkpoint does not exist, allowing you to not have to write 2 workflows.

I also add changes to move the checkpoint loading to the ForEachBlockPass to load blocks rather than from the IntermediatePasses themselves. I keep RestoreIntermediate and SaveIntermediate for backwards compatibility, but they should not be needed anymore.