### PR TITLE
Fix `KeyError` for already popped tasks

### DIFF
--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -524,7 +524,7 @@ class Worker:
             self._conn.send((RuntimeMessage.RESULT, packaged_result))
 
         # Remove task
-        self._tasks.pop(task.return_address)
+        self._tasks.pop(task.return_address, None)
 
         # Cancel any open tasks
         for mailbox_id in self._active_task.owned_mailboxes:


### PR DESCRIPTION
Some more complex instantiation workflows may have several instances of tasks with the same `RuntimeAddress`. In these cases, multiple calls to remove the task associated with the same `RuntimeAddress` may call `Worker._tasks.pop` after it has already been popped. 

Adding a default pop value of `None` avoids raising a `KeyError` in these scenarios.

Fixes #301 