### PR TITLE
Extend supported gate sets for qiskit conversion

### DIFF
--- a/bqskit/ext/qiskit/models.py
+++ b/bqskit/ext/qiskit/models.py
@@ -11,6 +11,8 @@ from bqskit.ir.gates.constant.cx import CNOTGate
 from bqskit.ir.gates.constant.cz import CZGate
 from bqskit.ir.gates.constant.sx import SXGate
 from bqskit.ir.gates.constant.x import XGate
+from bqskit.ir.gates.constant import IdentityGate
+from bqskit.ir.gates.constant import ECRGate
 from bqskit.ir.gates.parameterized import RZGate
 from bqskit.ir.gates.parameterized.u1 import U1Gate
 from bqskit.ir.gates.parameterized.u2 import U2Gate
@@ -35,6 +37,8 @@ def _basis_gate_str_to_bqskit_gate(basis_gates: list[str]) -> set[Gate]:
             gate_set.add(CNOTGate())
         elif basis_gate == 'cz':
             gate_set.add(CZGate())
+        elif basis_gate == 'ecr':
+            gate_set.add(ECRGate())
         elif basis_gate == 'u3':
             gate_set.add(U3Gate())
         elif basis_gate == 'u2':
@@ -49,4 +53,6 @@ def _basis_gate_str_to_bqskit_gate(basis_gates: list[str]) -> set[Gate]:
             gate_set.add(SXGate())
         elif basis_gate == 'p':
             gate_set.add(RZGate())
+        elif basis_gate == 'id':
+            gate_set.add(IdentityGate())
     return gate_set


### PR DESCRIPTION
This extension ensures that the gate sets of state-of-the-art IBM backends (tested with _quebec_ with gate set `['ecr', 'id', 'rz', 'sx', 'x']`) are supported when the machine model is loaded through `model_from_backend`.