### PR TITLE
Fix #302

### DIFF
--- a/bqskit/ir/lang/qasm2/qasm2.py
+++ b/bqskit/ir/lang/qasm2/qasm2.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from bqskit.ir.gates.measure import MeasurementPlaceholder
 from bqskit.ir.lang.language import LangException
 from bqskit.ir.lang.language import Language
 from bqskit.ir.lang.qasm2.parser import parse
 from bqskit.ir.lang.qasm2.visitor import OPENQASMVisitor
-from bqskit.ir.gates.measure import MeasurementPlaceholder
 
 if TYPE_CHECKING:
     from bqskit.ir.circuit import Circuit
@@ -35,7 +35,7 @@ class OPENQASM2Language(Language):
                 is_classical_register_present = True
 
             print(gate)
-            print("Gate definition:")
+            print('Gate definition:')
             print(gate.get_qasm_gate_def())
             source += gate.get_qasm_gate_def()
 

--- a/bqskit/ir/lang/qasm2/qasm2.py
+++ b/bqskit/ir/lang/qasm2/qasm2.py
@@ -7,6 +7,7 @@ from bqskit.ir.lang.language import LangException
 from bqskit.ir.lang.language import Language
 from bqskit.ir.lang.qasm2.parser import parse
 from bqskit.ir.lang.qasm2.visitor import OPENQASMVisitor
+from bqskit.ir.gates.measure import MeasurementPlaceholder
 
 if TYPE_CHECKING:
     from bqskit.ir.circuit import Circuit
@@ -22,7 +23,20 @@ class OPENQASM2Language(Language):
 
         source = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\n"
         source += f'qreg q[{circuit.num_qudits}];\n'
+        is_classical_register_present = False
         for gate in circuit.gate_set:
+            # add at maximum one classical register definition per gate
+            if isinstance(gate, MeasurementPlaceholder):
+                if is_classical_register_present:
+                    # skip all subsequent classical register definitions
+                    continue
+
+            if isinstance(gate, MeasurementPlaceholder):
+                is_classical_register_present = True
+
+            print(gate)
+            print("Gate definition:")
+            print(gate.get_qasm_gate_def())
             source += gate.get_qasm_gate_def()
 
         for op in circuit:

--- a/tests/ir/lang/test_qasm_encode.py
+++ b/tests/ir/lang/test_qasm_encode.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+from qiskit import ClassicalRegister
+from qiskit import QuantumCircuit
+from qiskit import QuantumRegister
+
+from bqskit.ext import qiskit_to_bqskit
 from bqskit.ir.circuit import Circuit
 from bqskit.ir.gates import CNOTGate
 from bqskit.ir.gates import Reset
 from bqskit.ir.gates import U3Gate
 from bqskit.ir.lang.qasm2 import OPENQASM2Language
-from bqskit.ext import qiskit_to_bqskit
-from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 
 
 class TestCircuitGates:

--- a/tests/ir/lang/test_qasm_encode.py
+++ b/tests/ir/lang/test_qasm_encode.py
@@ -5,6 +5,8 @@ from bqskit.ir.gates import CNOTGate
 from bqskit.ir.gates import Reset
 from bqskit.ir.gates import U3Gate
 from bqskit.ir.lang.qasm2 import OPENQASM2Language
+from bqskit.ext import qiskit_to_bqskit
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 
 
 class TestCircuitGates:
@@ -55,3 +57,98 @@ class TestCircuitGates:
             'reset q[0];\n'
         )
         assert qasm == expected
+
+    def test_classical_register(self) -> None:
+
+        # Section: Circuit
+        qr = QuantumRegister(2, name='qr')
+        cr = ClassicalRegister(2, name='cr')
+        qc = QuantumCircuit(qr, cr, name='qc')
+
+        qc.h(qr[0])
+        qc.cx(0, 1)
+
+        qc.measure(qr, cr)
+
+        bqc = qiskit_to_bqskit(qc)
+        print(bqc)
+
+        qasm = OPENQASM2Language().encode(bqc)
+        expected = (
+            'OPENQASM 2.0;\n'
+            'include "qelib1.inc";\n'
+            'qreg q[2];\n'
+            'creg cr[2];\n'
+            'h q[0];\n'
+            'cx q[0], q[1];\n'
+            'measure q[0] -> cr[0];\n'
+            'measure q[1] -> cr[1];\n'
+        )
+        assert qasm == expected
+
+    def test_multiple_classical_registers(self) -> None:
+        # Section: Circuit
+        qr = QuantumRegister(2, name='qr')
+        cr1 = ClassicalRegister(2, name='cr1')
+        cr2 = ClassicalRegister(2, name='cr2')
+        qc = QuantumCircuit(qr, cr1, cr2, name='qc')
+
+        qc.h(qr[0])
+        qc.h(qr[1])
+        qc.cx(qr[0], qr[1])
+
+        qc.measure(qr, cr1)
+        qc.measure(qr, cr2)
+
+        bqc = qiskit_to_bqskit(qc)
+        print(bqc)
+
+        qasm = OPENQASM2Language().encode(bqc)
+        expected = (
+            'OPENQASM 2.0;\n'
+            'include "qelib1.inc";\n'
+            'qreg q[2];\n'
+            'creg cr1[2];\n'
+            'creg cr2[2];\n'
+            'h q[0];\n'
+            'h q[1];\n'
+            'cx q[0], q[1];\n'
+            'measure q[0] -> cr1[0];\n'
+            'measure q[1] -> cr1[1];\n'
+            'measure q[0] -> cr2[0];\n'
+            'measure q[1] -> cr2[1];\n'
+        )
+        assert qasm == expected
+
+    def test_gate_count(self) -> None:
+        # Section: Circuit
+        qr = QuantumRegister(2, name='qr')
+        cr = ClassicalRegister(2, name='cr')
+        qc = QuantumCircuit(qr, cr, name='qc')
+
+        qc.h(qr[0])
+        qc.h(qr[1])
+        qc.cx(qr[0], qr[1])
+        qc.measure(qr, cr)
+
+        bqc = qiskit_to_bqskit(qc)
+        print(bqc)
+
+        qasm = OPENQASM2Language().encode(bqc)
+        expected = (
+            'OPENQASM 2.0;\n'
+            'include "qelib1.inc";\n'
+            'qreg q[2];\n'
+            'creg cr[2];\n'
+            'h q[0];\n'
+            'h q[1];\n'
+            'cx q[0], q[1];\n'
+            'measure q[0] -> cr[0];\n'
+            'measure q[1] -> cr[1];\n'
+        )
+        assert qasm == expected
+
+        print({
+            gate: bqc.count(gate)
+            for gate in bqc.gate_set
+        })


### PR DESCRIPTION
This PR addresses an issue with the QASM exporter, which previously failed to export circuits containing classical registers (see #302 ).

To ensure the correctness of the fix, I have added additional test cases to cover scenarios involving one or multiple classical registers imported via Qiskit. 

Please review the changes and let me know if you have any feedback or concerns.