### PR TITLE
radixes passed onto the object initializer

### DIFF
--- a/bqskit/qis/state/state.py
+++ b/bqskit/qis/state/state.py
@@ -200,7 +200,7 @@ class StateVector(NDArrayOperatorsMixin):
             radixes = [2] * num_qudits
         state = np.zeros(np.prod(radixes), dtype=np.complex128)
         state[0] = 1.0
-        return StateVector(state)
+        return StateVector(state, radixes=radixes)
 
     @staticmethod
     def random(num_qudits: int, radixes: Sequence[int] = []) -> StateVector:


### PR DESCRIPTION
Radixes parameter is computed but not passed to the StateVector constructor. Fixed the bug by adding it in the return statement with statevector. This solves the issue #305 