### PR TITLE
[Unitary hack] Use nbval to Automatically Validate Example and Tutorial Notebooks #316

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,15 @@ jobs:
         SYSTEM_VERSION_COMPAT: 0
       run: pip install .
 
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+
+    - name: Run Tox tests (including notebooks)
+      run: |
+        tox -e py${{ matrix.python-version }} -- pytest --nbval examples/tutorials/ --sanitize-with tests/nbval_sanitize.cfg {posargs}
+
     - name: Run tests
       env:
         NUMBER_RANDOM_CIRCUITS: 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ deps =
     qutip>=4.7.0
     pytket-qiskit
     tzdata
+    nbval
+    ipykernel
 commands =
     pytest {posargs}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -633,5 +633,31 @@ def r6_qudit_circuit(request: Any) -> Circuit:
     """Provide random 6-qudit random-radix circuits as a fixture."""
     return request.param[1].copy()
 
+@pytest.fixture(params=random_6_qudit_circuits(), ids=lambda circ: circ[0])
+def r6_qudit_circuit(request: Any) -> Circuit:
+    """Provide random 6-qudit random-radix circuits as a fixture."""
+    return request.param[1].copy()
+
+def pytest_collectstart(collector):
+    """
+    Hook to modify collection.
+    Here, we use it to tell nbval to skip comparing certain output types
+    for all notebooks.
+    """
+    if collector.fspath and collector.fspath.ext == '.ipynb':
+        if not hasattr(collector, 'skip_compare'):
+            collector.skip_compare = ()
+        # Add MIME types you want to globally ignore for comparison.
+        # Common ones include:
+        # 'text/html' - if HTML representations are too volatile
+        # 'application/javascript' - for widgets or interactive elements
+        # 'image/png', 'image/jpeg' - if you don't want to compare images
+        # 'application/vnd.jupyter.widget-view+json' - for Jupyter widgets
+        # 'stderr' - if stderr output is noisy and not critical for validation
+        collector.skip_compare += (
+            'text/html',
+            'application/javascript',
+            # 'stderr', # Uncomment if you want to ignore stderr globally
+        )
 
 # endregion

--- a/tests/nbval_sanitize.cfg
+++ b/tests/nbval_sanitize.cfg
@@ -1,0 +1,32 @@
+_sanitize.cfg
+[regex1]
+# General date-like patterns (e.g., 01/01/2023, 01-01-23)
+regex: \d{1,2}[-/]\d{1,2}[-/]\d{2,4}
+replace: DATE-STAMP
+
+[regex2]
+# General time-like patterns (e.g., 12:34:56)
+regex: \d{2}:\d{2}:\d{2}
+replace: TIME-STAMP
+
+[regex3]
+# Matplotlib object memory addresses
+regex: <matplotlib\.(?:figure\.Figure|axes\._axes\.Axes|image\.AxesImage|lines\.Line2D|text\.Text|collections\.PathCollection|legend\.Legend) object at 0x[0-9a-fA-F]+>
+replace: MATPLOTLIB-OBJECT
+
+[regex4]
+# Generic memory addresses (e.g., 0x7f..., <object at 0x...>)
+regex: 0x[0-9a-fA-F]+
+replace: MEMORY-ADDRESS
+
+[regex5]
+# Progress bar percentages and iteration counts that might vary slightly
+regex: \s*\d{1,3}%\|.*?\|\s*\d+/\d+\s*\[\d{2}:\d{2}<\d{2}:\d{2}.*?\]
+replace: PROGRESS-BAR
+
+[regex6]
+# Floating point numbers - adjust precision as needed, or make more specific
+# This example matches a number like "1.2345e-05" or "0.123"
+# Be cautious with overly broad float regexes if precise float values are important
+regex: [-+]?\d*\.\d+([eE][-+]?\d+)?
+replace: FLOAT-VALUE-SANITIZED


### PR DESCRIPTION
1.  **pyproject.toml**:
    *   Modifications to the `[tool.tox.legacy_tox_ini]` section, specifically under `[testenv.deps]`, to add:
        *   `nbval`
        *   `ipykernel`

2.  **nbval_sanitize.cfg**:
    *   This is a **new file** containing regular expressions to sanitize notebook outputs (e.g., for dates, times, memory addresses).

3.  **tests.yml** (or your equivalent CI workflow file):
    *   Updates to the testing job(s) to include a command that runs `nbval`, for example:
        ```yaml
        tox -e py<python-version> -- pytest --nbval examples/tutorials/ --sanitize-with tests/nbval_sanitize.cfg
        ```
        (Ensure this command is adapted to your specific CI matrix and tox environment naming).

4.  **conftest.py**:
    *   Addition or modification of the `pytest_collectstart(collector)` function to globally skip comparing certain output MIME types for notebooks (e.g., `text/html`, `application/javascript`).

5.  **Jupyter Notebooks in tutorials**:
    *   Any notebooks that required cell-specific annotations like `# NBVAL_IGNORE_OUTPUT` or `# NBVAL_SKIP` to handle dynamic or long-running cells.
    *   Ensure all notebooks in this directory have been run and saved with their latest, correct outputs, as these will serve as the reference for `nbval` tests.