### PR TITLE
Add full-level MPX decomposition to MGDPass for optimal Block ZXZ performance

### DIFF
--- a/bqskit/passes/synthesis/qsd.py
+++ b/bqskit/passes/synthesis/qsd.py
@@ -98,7 +98,7 @@ class FullQSDPass(BasePass):
         # Instantiate the helper QSD pass
         self.qsd = QSDPass(min_qudit_size=min_qudit_size)
         # Instantiate the helper Multiplex Gate Decomposition pass
-        self.mgd = MGDPass(decompose_twice=False)
+        self.mgd = MGDPass(decompose_twice=False, decompose_all=True)
         self.perform_scan = perform_scan
 
     async def run(self, circuit: Circuit, data: PassData) -> None:
@@ -129,8 +129,12 @@ class MGDPass(BasePass):
         ISSN 0024-3795,
         https://arxiv.org/pdf/quant-ph/0406176.pdf
     """
-
+    
     def __init__(self, decompose_twice: bool = True) -> None:
+        self.decompose_twice = decompose_twice
+        self.decompose_all = not decompose_twice
+
+    def __init__(self, decompose_twice: bool, decompose_all: bool) -> None:
         """
         The MGDPass decomposes all MPRY and MPRZ gates in a circuit.
 
@@ -140,6 +144,8 @@ class MGDPass(BasePass):
             the pass will only decompose one level. (Default: True)
         """
         self.decompose_twice = decompose_twice
+        self.decompose_all = decompose_all
+    
 
     @staticmethod
     def decompose_mpx_one_level(
@@ -288,6 +294,72 @@ class MGDPass(BasePass):
                 circ.append_circuit(op, list(range(1, num_qudits)))
 
         return circ
+    
+    @staticmethod 
+    def decompose_mpx_all_levels(
+        decompose_ry: bool,
+        params: RealVector,
+        num_qudits: int,
+        reverse: bool = False,
+        drop_last_cnot: bool = False,
+    ) -> Circuit:
+        
+        if num_qudits < 4:
+            # If you have less than 3 qubits, just decompose one level
+            return MGDPass.decompose_mpx_two_levels(
+                decompose_ry=decompose_ry,
+                params=params,
+                num_qudits=num_qudits,
+                reverse=reverse,
+                drop_last_cnot=drop_last_cnot,
+            )
+        
+        # Retrieves decomposition of multiplexed Ry gate after ONE ROUND
+        left_params, right_params = MPRYGate.get_decomposition(params) 
+
+        circ_left = MGDPass.decompose_mpx_all_levels(
+            decompose_ry=decompose_ry,
+            params=left_params,
+            num_qudits=num_qudits - 1,
+            reverse=reverse,
+            drop_last_cnot=True
+        )
+
+        circ_right = MGDPass.decompose_mpx_all_levels(
+            decompose_ry=decompose_ry,
+            params=right_params,
+            num_qudits=num_qudits - 1,
+            reverse=not reverse,
+            drop_last_cnot=True
+        )
+
+        circ = Circuit(num_qudits)
+        cx_location_big = (0, num_qudits - 1)
+
+        # U = V * CNOT * W * CNOT – decomposition from https://arxiv.org/pdf/quant-ph/0406176
+        ops: list[Circuit | Operation] = [
+            circ_left,
+            Operation(CNOTGate(), cx_location_big),
+            circ_right,
+            Operation(CNOTGate(), cx_location_big),
+        ]
+
+        # removes 2^k CNOTs (2 per level) – neat optimization trick from https://arxiv.org/pdf/2403.13692 (5.2)
+        if drop_last_cnot:
+            ops.pop()
+
+        if reverse:
+            ops.reverse()
+
+        for op in ops:
+            if isinstance(op, Operation):
+                circ.append(op)
+            else:
+                circ.append_circuit(op, list(range(1, num_qudits)))
+
+        return circ
+        
+
 
     async def run(self, circuit: Circuit, data: PassData) -> None:
         """Decompose all MPRY and MPRZ gates in the circuit one level."""
@@ -313,7 +385,15 @@ class MGDPass(BasePass):
 
         if len(ops) > 0:
             # Do a bulk QSDs -> circs
-            if self.decompose_twice:
+            if self.decompose_all:
+                circs = [
+                    MGDPass.decompose_mpx_all_levels(
+                        isinstance(op.gate, MPRYGate),
+                        op.params,
+                        op.num_qudits,
+                    ) for op in ops
+                ]
+            elif self.decompose_twice:
                 circs = [
                     MGDPass.decompose_mpx_two_levels(
                         isinstance(op.gate, MPRYGate),


### PR DESCRIPTION
✅ Main Changes:
- This PR adds support for **full-level decomposition** of multiplexed gates (MPX) in MGDPass, enabling the Block ZXZ decomposition to reach theoretical CNOT count lower bounds as described in [this paper](https://arxiv.org/pdf/2403.13692). 
- Specifically, I implemented `MGDPass.decompose_mpx_all_levels(...)` which recursively decomposes MPRY or MPRZ gates, and applied an optimization technique described in Section 5.2 of the paper which eliminates 2 CNOT gates per merge. I then integrated this full-level decomposition into the workflow in `bzxz.py`. I also updated MGDPass instantiation to support both `decompose_twice` and `decompose_all` configurations. 

🧪 Motivation & Results:
- Previously, our earlier two-level decomposition of multiplexed gates yielded **107 CNOTs** for a 4-qubit gate – exceeding the proposed 95 CNOTs described in the paper
- After enabling full decomposition, the implementation now matches the theoretical lower bound, verifying the correctness of this optimization. See below gate count for a test run on a 4 qubit circuit:
<img width="301" alt="Screenshot 2025-06-11 at 20 13 07" src="https://github.com/user-attachments/assets/82b24529-959b-44d4-8c96-a928eea61b4d" />

62 + (15 * 2) + (1 * 3) = 95 total CNOTs – for an *n*-qubit variable unitary, *n-1* of them can be implemented by 2 CNOTs while the remaining 1 qubit is implemented by 3 CNOTs.

📎 References:
- [Circuit Construction for General
n-Qubit Gates Based on Block ZXZ-Decomposition](https://arxiv.org/pdf/2403.13692)
- [Synthesis of Quantum Logic Gates](https://arxiv.org/pdf/quant-ph/0406176)

Tagging @jkalloor3!