### PR TITLE
Fix #365: Set MeasurementPlaceholder _qasm_name to 'measurement'

### DIFF
--- a/bqskit/ir/gates/measure.py
+++ b/bqskit/ir/gates/measure.py
@@ -28,7 +28,7 @@ class MeasurementPlaceholder(Gate):
                 a tuple containing the classical register's name and index.
         """
         self._name = 'measurement'
-        self._qasm_name = 'measure'
+        self._qasm_name = 'measurement'
         self._num_qudits = len(measurements)
         self._radixes = tuple([2] * self._num_qudits)
         self._num_params = 0


### PR DESCRIPTION
Fixes #365