### PR TITLE
Fix CI

### DIFF
--- a/bqskit/exec/runners/quest.py
+++ b/bqskit/exec/runners/quest.py
@@ -130,7 +130,11 @@ class QuestRunner(CircuitRunner):
         # 5. Average and return results
         probs = np.sum(np.array([result.probs for result in results]), axis=0)
         probs /= self.sample_size
-        return RunnerResults(circuit.num_qudits, circuit.radixes, probs)
+        return RunnerResults(
+            circuit.num_qudits,
+            circuit.radixes,
+            probs.tolist(),
+        )
 
     def parse_data(
         self,

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -772,8 +772,8 @@ def start_worker(
 
     # Pin worker to cpu
     if cpu is not None:
-        if sys.platform == 'win32':
-            raise RuntimeError('Cannot pin worker to cpu on windows.')
+        if not hasattr(os, 'sched_setaffinity'):
+            raise RuntimeError('CPU pinning is not supported on this platform.')
         os.sched_setaffinity(0, [cpu])
 
     # Connect to manager


### PR DESCRIPTION
Fixes two issues:

1. Mypy was complaining that `os.sched_setaffinity` is not available on macOS, but this never failed in CI since the runner is Linux. I updated to check `hasattr(os, 'sched_setaffinity')` instead.
```pytb
bqskit/runtime/worker.py:777: error: Module has no attribute
"sched_setaffinity"  [attr-defined]
            os.sched_setaffinity(0, [cpu])
            ^~~~~~~~~~~~~~~~~~~~
```

2.
```pytb
bqskit/exec/runners/quest.py:133: error: Argument 3 to "RunnerResults" has
incompatible type "ndarray[Any, Any]"; expected "Sequence[float]"  [arg-type]
    ...      return RunnerResults(circuit.num_qudits, circuit.radixes, probs)
                                                                       ^~~~~
Found 2 errors in 2 files (checked 513 source files)
```

Fixed by changing `probs` to `probs.to_list()`