### PR TITLE
Use `sys.executable` for runtime process starting

### DIFF
--- a/bqskit/runtime/detached.py
+++ b/bqskit/runtime/detached.py
@@ -469,3 +469,7 @@ def start_server() -> None:
 
     # Start the server
     server.run()
+
+
+if __name__ == '__main__':
+    start_server()

--- a/bqskit/runtime/manager.py
+++ b/bqskit/runtime/manager.py
@@ -375,3 +375,7 @@ def start_manager() -> None:
 
     # Start the manager
     manager.run()
+
+
+if __name__ == '__main__':
+    start_manager()

--- a/bqskit/runtime/worker.py
+++ b/bqskit/runtime/worker.py
@@ -921,3 +921,7 @@ def start_worker_rank() -> None:
     # Join them
     for proc in procs:
         proc.join()
+
+
+if __name__ == '__main__':
+    start_worker_rank()

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -16,8 +16,15 @@ params = ['attached', 'detached'] if sys.platform != 'win32' else ['attached']
 @pytest.fixture(params=params)
 def server_compiler(request: Any) -> Iterator[Compiler]:
     if request.param == 'detached':
-        manager = subprocess.Popen(['bqskit-manager', '-n2', '-i'])
-        server = subprocess.Popen(['bqskit-server', 'localhost', '-i'])
+        manager = subprocess.Popen(
+            [sys.executable, '-m', 'bqskit.runtime.manager', '-n2', '-i'],
+        )
+        server = subprocess.Popen(
+            [
+                sys.executable, '-m', 'bqskit.runtime.detached',
+                'localhost', '-i',
+            ],
+        )
         compiler = Compiler('localhost')
     else:
         compiler = Compiler(num_workers=2, runtime_log_level=1)

--- a/tests/runtime/test_attached.py
+++ b/tests/runtime/test_attached.py
@@ -98,7 +98,7 @@ def test_interrupt_handling() -> None:
 
     in_num_childs = len(psutil.Process(os.getpid()).children(recursive=True))
     p = subprocess.Popen([
-        'python', '-c',
+        sys.executable, '-c',
         """
         import time
         from bqskit.compiler import Compiler


### PR DESCRIPTION
In the runtime tests, BQSKit tries to do something along the lines of:
```py
subprocess.Popen(['bqskit-manager', ...])
```

This fails when using, for example, `uv`, since `bqskit-manager` is not installed into PATH.

Using `sys.executable -m bqskit.runtime.manager` and adding an if-name-main guard to run it as a module fixes this.