### PR TITLE
Fix ZXZXZDecomposition doubling synthesis for diagonal unitaries

### DIFF
--- a/bqskit/passes/rules/zxzxz.py
+++ b/bqskit/passes/rules/zxzxz.py
@@ -13,6 +13,12 @@ from bqskit.ir.gates.parameterized.rx import RXGate
 from bqskit.ir.gates.parameterized.rz import RZGate
 from bqskit.ir.gates.parameterized.u1 import U1Gate
 
+# Tolerance for recognizing the ZXZXZ middle rotation angle as Clifford (0 or
+# +-pi). This only has to separate those two values from every other angle
+# the decomposition produces, and both come out exact to floating-point
+# precision, so this can be tight.
+_CLIFFORD_ANGLE_TOL = 1e-10
+
 
 class ZXZXZDecomposition(BasePass):
     """
@@ -81,6 +87,22 @@ class ZXZXZDecomposition(BasePass):
         t = (t + np.pi) % (2 * np.pi) - np.pi
         p = (p + np.pi) % (2 * np.pi) - np.pi
         l = (l + np.pi) % (2 * np.pi) - np.pi
+
+        # When the middle rotation is Clifford (t == 0 or +-pi), the middle
+        # SX.RZ(t).SX block is diagonal (or X) and commutes with the outer RZ
+        # gates, so only l + p (or p - l) is actually determined by the
+        # target unitary -- how that total is split between the two outer
+        # gates is a free gauge choice. Splitting it evenly, as the formulas
+        # above do unconditionally, turns one gate that needs synthesis into
+        # two (e.g. every diagonal single-qubit unitary, which is common in
+        # practice -- any run of Z-axis rotations reduces to one). Collapse
+        # the gauge instead, so the whole rotation lands on one outer gate
+        # and the other becomes a free identity (angle 0, exact in both RZ
+        # and U1 parameterization).
+        if abs(abs(t) - np.pi) < _CLIFFORD_ANGLE_TOL:
+            l, p = 0.0, (l + p + np.pi) % (2 * np.pi) - np.pi
+        elif abs(t) < _CLIFFORD_ANGLE_TOL:
+            l, p = 0.0, (p - l + np.pi) % (2 * np.pi) - np.pi
 
         new_circuit = Circuit(1)
 

--- a/tests/passes/rules/test_zxzxz.py
+++ b/tests/passes/rules/test_zxzxz.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import numpy as np
+
 from bqskit.compiler.compiler import Compiler
 from bqskit.ir.circuit import Circuit
+from bqskit.ir.gates.parameterized.rz import RZGate
 from bqskit.passes import ZXZXZDecomposition
 from bqskit.qis import UnitaryMatrix
 
@@ -12,3 +15,30 @@ def test_zxzxz_decomposition(compiler: Compiler) -> None:
         test_circuit = Circuit.from_unitary(test_utry)
         out_circuit = compiler.compile(test_circuit, ZXZXZDecomposition())
         assert out_circuit.get_unitary().get_distance_from(test_utry) < 5e-8
+
+
+def test_zxzxz_decomposition_diagonal_collapses_gauge(
+    compiler: Compiler,
+) -> None:
+    """A diagonal target's middle rotation is Clifford, so the two outer
+    RZ gates are only constrained as a sum/difference -- how that total is
+    split between them is a free gauge choice. Splitting it evenly, as the
+    unconstrained formulas would, turns one gate needing synthesis into two.
+    The decomposition should instead collapse the gauge onto a single gate,
+    leaving the other an exact identity (angle 0)."""
+    rng = np.random.default_rng(0)
+    for _ in range(20):
+        theta = rng.uniform(-np.pi, np.pi)
+        test_circuit = Circuit(1)
+        test_circuit.append_gate(RZGate(), 0, [theta])
+        test_utry = test_circuit.get_unitary()
+
+        out_circuit = compiler.compile(test_circuit, ZXZXZDecomposition())
+        assert out_circuit.get_unitary().get_distance_from(test_utry) < 5e-8
+
+        angles = [
+            op.params[0]
+            for op in out_circuit
+            if op.gate.num_params == 1
+        ]
+        assert any(abs(angle) < 1e-9 for angle in angles)


### PR DESCRIPTION
When the middle rotation is Clifford (t == 0 or +-pi), the SX.RZ(t).SX block commutes with the outer RZ/U1 gates, so only their sum or difference is actually determined by the target unitary -- how that total is split between the two outer gates is a free gauge choice. The unconstrained formulas split it evenly, turning one gate that needs synthesis into two. This is the common case: any diagonal single-qubit unitary, e.g. every run of Z-axis rotations, hits it.

Collapse the gauge instead so the whole rotation lands on one outer gate and the other becomes an exact identity (angle 0).